### PR TITLE
Dotnet Fan-out-fan-in

### DIFF
--- a/samples/portable-sdks/dotnet/AspNetWebApp/AspNetWebApp.csproj
+++ b/samples/portable-sdks/dotnet/AspNetWebApp/AspNetWebApp.csproj
@@ -11,8 +11,8 @@
   <ItemGroup>
     <PackageReference Include="Azure.Identity" Version="1.13.1" />
     <PackageReference Include="Grpc.Net.Client" Version="2.67.0" />
-    <PackageReference Include="Microsoft.DurableTask.Client.AzureManaged" Version="1.8.1-preview.1" />
-    <PackageReference Include="Microsoft.DurableTask.Worker.AzureManaged" Version="1.8.1-preview.1" />
+    <PackageReference Include="Microsoft.DurableTask.Client.AzureManaged" Version="1.10.0-preview.1" />
+    <PackageReference Include="Microsoft.DurableTask.Worker.AzureManaged" Version="1.10.0-preview.1" />
     <PackageReference Include="Microsoft.DurableTask.Generators" Version="1.0.0-preview.1" OutputItemType="Analyzer" />
     <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="8.0.1" />
   </ItemGroup>

--- a/samples/portable-sdks/dotnet/EntitiesSample/AccountTransferBackend.csproj
+++ b/samples/portable-sdks/dotnet/EntitiesSample/AccountTransferBackend.csproj
@@ -9,8 +9,8 @@
   <ItemGroup>
     <PackageReference Include="Azure.Identity" Version="1.13.1" />
     <PackageReference Include="Grpc.Net.Client" Version="2.67.0" />
-    <PackageReference Include="Microsoft.DurableTask.Client.AzureManaged" Version="1.8.1-preview.1" />
-    <PackageReference Include="Microsoft.DurableTask.Worker.AzureManaged" Version="1.8.1-preview.1" />
+    <PackageReference Include="Microsoft.DurableTask.Client.AzureManaged" Version="1.10.0-preview.1" />
+    <PackageReference Include="Microsoft.DurableTask.Worker.AzureManaged" Version="1.10.0-preview.1" />
     <PackageReference Include="Microsoft.DurableTask.Generators" Version="1.0.0-preview.1" OutputItemType="Analyzer" />
     <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="8.0.1" />
   </ItemGroup>

--- a/samples/portable-sdks/dotnet/FanOutFanIn/Client/Client.csproj
+++ b/samples/portable-sdks/dotnet/FanOutFanIn/Client/Client.csproj
@@ -1,0 +1,17 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>net8.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+  </PropertyGroup>
+  <ItemGroup>
+    <PackageReference Include="Azure.Identity" Version="1.13.1" />
+    <PackageReference Include="Grpc.Net.Client" Version="2.67.0" />
+    <PackageReference Include="Microsoft.DurableTask.Client.AzureManaged" Version="1.8.1-preview.1" />
+    <PackageReference Include="Microsoft.DurableTask.Generators" Version="1.0.0-preview.1" OutputItemType="Analyzer" />
+    <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="8.0.1" />
+  </ItemGroup>
+
+</Project>

--- a/samples/portable-sdks/dotnet/FanOutFanIn/Client/Client.csproj
+++ b/samples/portable-sdks/dotnet/FanOutFanIn/Client/Client.csproj
@@ -9,7 +9,7 @@
   <ItemGroup>
     <PackageReference Include="Azure.Identity" Version="1.13.1" />
     <PackageReference Include="Grpc.Net.Client" Version="2.67.0" />
-    <PackageReference Include="Microsoft.DurableTask.Client.AzureManaged" Version="1.8.1-preview.1" />
+    <PackageReference Include="Microsoft.DurableTask.Client.AzureManaged" Version="1.10.0-preview.1" />
     <PackageReference Include="Microsoft.DurableTask.Generators" Version="1.0.0-preview.1" OutputItemType="Analyzer" />
     <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="8.0.1" />
   </ItemGroup>

--- a/samples/portable-sdks/dotnet/FanOutFanIn/Client/Program.cs
+++ b/samples/portable-sdks/dotnet/FanOutFanIn/Client/Program.cs
@@ -1,0 +1,123 @@
+using Azure.Identity;
+using Microsoft.DurableTask;
+using Microsoft.DurableTask.Client;
+using Microsoft.DurableTask.Client.AzureManaged;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+using System.Collections.Generic;
+using System.Text.Json;
+
+// Configure logging
+using ILoggerFactory loggerFactory = LoggerFactory.Create(builder =>
+{
+    builder.AddConsole();
+    builder.SetMinimumLevel(LogLevel.Information);
+});
+
+ILogger<Program> logger = loggerFactory.CreateLogger<Program>();
+logger.LogInformation("Starting Fan-Out Fan-In Pattern - Parallel Processing Client");
+
+// Get environment variables for endpoint and taskhub with defaults
+string endpoint = Environment.GetEnvironmentVariable("ENDPOINT") ?? "http://localhost:8080";
+string taskHubName = Environment.GetEnvironmentVariable("TASKHUB") ?? "default";
+
+// Split the endpoint if it contains authentication info
+string hostAddress = endpoint;
+if (endpoint.Contains(';'))
+{
+    hostAddress = endpoint.Split(';')[0];
+}
+
+// Determine if we're connecting to the local emulator
+bool isLocalEmulator = endpoint == "http://localhost:8080";
+
+// Construct a proper connection string with authentication
+string connectionString;
+if (isLocalEmulator)
+{
+    // For local emulator, no authentication needed
+    connectionString = $"Endpoint={hostAddress};TaskHub={taskHubName};Authentication=None";
+    logger.LogInformation("Using local emulator with no authentication");
+}
+else
+{
+    // For Azure, use DefaultAzureCredential
+    connectionString = $"Endpoint={hostAddress};TaskHub={taskHubName};Authentication=DefaultAzureCredential";
+    logger.LogInformation("Using Azure endpoint with DefaultAzureCredential");
+}
+
+logger.LogInformation("Using endpoint: {Endpoint}", endpoint);
+logger.LogInformation("Using task hub: {TaskHubName}", taskHubName);
+logger.LogInformation("Host address: {HostAddress}", hostAddress);
+logger.LogInformation("Connection string: {ConnectionString}", connectionString);
+logger.LogInformation("This client submits a list of work items for parallel processing");
+
+// Create the client using DI service provider
+ServiceCollection services = new ServiceCollection();
+services.AddLogging(builder => builder.AddConsole());
+
+// Register the client
+services.AddDurableTaskClient(options =>
+{
+    options.UseDurableTaskScheduler(connectionString);
+});
+
+ServiceProvider serviceProvider = services.BuildServiceProvider();
+DurableTaskClient client = serviceProvider.GetRequiredService<DurableTaskClient>();
+
+// Create a list of work items to process in parallel
+List<string> workItems = new List<string>
+{
+    "Task1",
+    "Task2",
+    "Task3",
+    "LongerTask4",
+    "VeryLongTask5"
+};
+
+logger.LogInformation("Starting parallel processing orchestration with {Count} work items", workItems.Count);
+logger.LogInformation("Work items: {WorkItems}", JsonSerializer.Serialize(workItems));
+
+// Schedule the orchestration
+string instanceId = await client.ScheduleNewOrchestrationInstanceAsync(
+    "ParallelProcessingOrchestration", 
+    workItems);
+
+logger.LogInformation("Started orchestration with ID: {InstanceId}", instanceId);
+
+// Wait for orchestration to complete
+logger.LogInformation("Waiting for orchestration to complete...");
+
+// Create a cancellation token source with timeout
+using CancellationTokenSource cts = new CancellationTokenSource(TimeSpan.FromSeconds(30));
+
+// Wait for the orchestration to complete using built-in method
+OrchestrationMetadata instance = await client.WaitForInstanceCompletionAsync(
+    instanceId,
+    getInputsAndOutputs: true,
+    cts.Token);
+
+logger.LogInformation("Orchestration completed with status: {Status}", instance.RuntimeStatus);
+
+if (instance.RuntimeStatus == OrchestrationRuntimeStatus.Completed)
+{
+    Dictionary<string, int>? results = instance.ReadOutputAs<Dictionary<string, int>>();
+    logger.LogInformation("Processing results:");
+    if (results != null)
+    {
+        foreach (KeyValuePair<string, int> result in results)
+        {
+            logger.LogInformation("Work item: {Item}, Result: {Result}", result.Key, result.Value);
+        }
+        
+        logger.LogInformation("Total items processed: {Count}", results.Count);
+    }
+    else
+    {
+        logger.LogWarning("No results were returned from the orchestration.");
+    }
+}
+else if (instance.RuntimeStatus == OrchestrationRuntimeStatus.Failed)
+{
+    logger.LogError("Orchestration failed: {ErrorMessage}", instance.FailureDetails?.ErrorMessage);
+}

--- a/samples/portable-sdks/dotnet/FanOutFanIn/README.md
+++ b/samples/portable-sdks/dotnet/FanOutFanIn/README.md
@@ -1,0 +1,287 @@
+# Fan-Out Fan-In Pattern
+
+## Description of the Sample
+
+This sample demonstrates the Fan-Out Fan-In pattern with the Azure Durable Task Scheduler using the .NET SDK. The Fan-Out Fan-In pattern represents a way to execute multiple operations in parallel and then aggregate the results, making it ideal for parallelized data processing scenarios.
+
+In this sample:
+1. The orchestrator takes a list of work items as input
+2. It fans out by creating a separate task for each work item using `ProcessWorkItemActivity` 
+3. All these tasks execute in parallel
+4. It waits for all tasks to complete using `Task.WhenAll`
+5. It fans in by aggregating all individual results using `AggregateResultsActivity`
+6. The final aggregated result is returned to the client
+
+This pattern is useful for:
+- Processing large datasets in parallel for improved throughput
+- Batch processing operations that can be executed independently
+- Distributing computational workload across multiple workers
+- Aggregating results from multiple sources or computations
+
+## Prerequisites
+
+1. [.NET 8 SDK](https://dotnet.microsoft.com/download/dotnet/8.0) or later
+2. [Docker](https://www.docker.com/products/docker-desktop/) (for running the emulator)
+3. [Azure CLI](https://docs.microsoft.com/cli/azure/install-azure-cli) (if using a deployed Durable Task Scheduler)
+
+## Configuring Durable Task Scheduler
+
+There are two ways to run this sample:
+
+### Using the Emulator (Recommended)
+
+The emulator simulates a scheduler and taskhub in a Docker container, making it ideal for development and learning.
+
+1. Install Docker if it's not already installed.
+
+2. Pull the Docker Image for the Emulator:
+```bash
+docker pull mcr.microsoft.com/dts/dts-emulator:v0.0.6
+```
+
+3. Run the Emulator:
+```bash
+docker run --name dtsemulator -d -p 8080:8080 -p 8082:8082 mcr.microsoft.com/dts/dts-emulator:v0.0.6
+```
+Wait a few seconds for the container to be ready.
+
+Note: The example code automatically uses the default emulator settings (endpoint: http://localhost:8080, taskhub: default). You don't need to set any environment variables.
+
+### Using a Deployed Scheduler and Taskhub in Azure
+
+For production scenarios or when you're ready to deploy to Azure:
+
+1. Create a Scheduler using the Azure CLI:
+```bash
+az durabletask scheduler create --resource-group <testrg> --name <testscheduler> --location <eastus> --ip-allowlist "[0.0.0.0/0]" --sku-capacity 1 --sku-name "Dedicated" --tags "{'myattribute':'myvalue'}"
+```
+
+2. Create Your Taskhub:
+```bash
+az durabletask taskhub create --resource-group <testrg> --scheduler-name <testscheduler> --name <testtaskhub>
+```
+
+3. Retrieve the Endpoint for the Scheduler from the Azure portal.
+
+4. Set the Environment Variables:
+
+   Bash:
+   ```bash
+   export TASKHUB=<taskhubname>
+   export ENDPOINT=<taskhubEndpoint>
+   ```
+
+   PowerShell:
+   ```powershell
+   $env:TASKHUB = "<taskhubname>"
+   $env:ENDPOINT = "<taskhubEndpoint>"
+   ```
+
+## Authentication
+
+The sample includes smart detection of the environment and configures authentication automatically:
+
+- For local development with the emulator (when endpoint is http://localhost:8080), no authentication is required.
+- For Azure deployments, DefaultAzureCredential is used, which tries multiple authentication methods:
+  - Managed Identity
+  - Environment variables (AZURE_CLIENT_ID, AZURE_TENANT_ID, AZURE_CLIENT_SECRET)
+  - Azure CLI login
+  - Visual Studio login
+  - and more
+
+The connection string is constructed dynamically based on the environment:
+```csharp
+// For local emulator
+connectionString = $"Endpoint={hostAddress};TaskHub={taskHubName};Authentication=None";
+
+// For Azure
+connectionString = $"Endpoint={hostAddress};TaskHub={taskHubName};Authentication=DefaultAzureCredential";
+```
+
+## How to Run the Sample
+
+Once you have set up either the emulator or deployed scheduler, follow these steps to run the sample:
+
+1. First, build the solution:
+```bash
+cd FanOutFanIn
+dotnet build
+```
+
+2. Start the worker in a terminal:
+```bash
+cd Worker
+dotnet run
+```
+You should see output indicating the worker has started and registered the orchestration and activities.
+
+3. In a new terminal, run the client:
+```bash
+cd Client
+dotnet run
+```
+
+## Understanding the Code Structure
+
+### Worker Project
+
+The Worker project contains:
+
+- **ParallelProcessingOrchestration.cs**: Defines the orchestrator and activity functions in a single file
+- **Program.cs**: Sets up the worker host with proper connection string handling
+
+#### Orchestration Implementation
+
+The orchestration uses the fan-out fan-in pattern by creating parallel activity tasks and waiting for all to complete:
+
+```csharp
+public override async Task<Dictionary<string, int>> RunAsync(TaskOrchestrationContext context, List<string> workItems)
+{
+    // Step 1: Fan-out by creating a task for each work item in parallel
+    List<Task<Dictionary<string, int>>> processingTasks = new List<Task<Dictionary<string, int>>>();
+    
+    foreach (string workItem in workItems)
+    {
+        // Create a task for each work item (fan-out)
+        Task<Dictionary<string, int>> task = context.CallActivityAsync<Dictionary<string, int>>(
+            nameof(ProcessWorkItemActivity), workItem);
+        processingTasks.Add(task);
+    }
+    
+    // Step 2: Wait for all parallel tasks to complete
+    Dictionary<string, int>[] results = await Task.WhenAll(processingTasks);
+    
+    // Step 3: Fan-in by aggregating all results
+    Dictionary<string, int> aggregatedResults = await context.CallActivityAsync<Dictionary<string, int>>(
+        nameof(AggregateResultsActivity), results);
+    
+    return aggregatedResults;
+}
+```
+
+Each activity is implemented as a separate class decorated with the `[DurableTask]` attribute:
+
+```csharp
+[DurableTask]
+public class ProcessWorkItemActivity : TaskActivity<string, Dictionary<string, int>>
+{
+    // Implementation processes a single work item
+}
+
+[DurableTask]
+public class AggregateResultsActivity : TaskActivity<Dictionary<string, int>[], Dictionary<string, int>>
+{
+    // Implementation aggregates individual results
+}
+```
+
+The worker uses Microsoft.Extensions.Hosting for proper lifecycle management:
+```csharp
+builder.Services.AddDurableTaskWorker()
+    .AddTasks(registry =>
+    {
+        registry.AddOrchestrator<ParallelProcessingOrchestration>();
+        registry.AddActivity<ProcessWorkItemActivity>();
+        registry.AddActivity<AggregateResultsActivity>();
+    })
+    .UseDurableTaskScheduler(connectionString);
+```
+
+### Client Project
+
+The Client project:
+
+- Uses the same connection string logic as the worker
+- Creates a list of work items to be processed in parallel
+- Schedules an orchestration instance with the list as input
+- Waits for the orchestration to complete and displays the aggregated results
+- Uses WaitForInstanceCompletionAsync for efficient polling
+
+```csharp
+List<string> workItems = new List<string>
+{
+    "Task1",
+    "Task2",
+    "Task3",
+    "LongerTask4",
+    "VeryLongTask5"
+};
+
+// Schedule the orchestration with the work items
+string instanceId = await client.ScheduleNewOrchestrationInstanceAsync(
+    "ParallelProcessingOrchestration", 
+    workItems);
+
+// Wait for completion
+var instance = await client.WaitForInstanceCompletionAsync(
+    instanceId,
+    getInputsAndOutputs: true,
+    cts.Token);
+```
+
+## Understanding the Output
+
+When you run the client, you should see:
+1. The client starting an orchestration with a list of work items
+2. The worker processing each work item in parallel
+3. The worker aggregating all results
+4. The client displaying the final aggregated results from the completed orchestration
+
+Example output:
+```
+Starting Fan-Out Fan-In Pattern - Parallel Processing Client
+Using local emulator with no authentication
+Starting parallel processing orchestration with 5 work items
+Work items: ["Task1","Task2","Task3","LongerTask4","VeryLongTask5"]
+Started orchestration with ID: 7f8e9a6b-1c2d-3e4f-5a6b-7c8d9e0f1a2b
+Waiting for orchestration to complete...
+Orchestration completed with status: Completed
+Processing results:
+Work item: Task1, Result: 5
+Work item: Task2, Result: 5
+Work item: Task3, Result: 5
+Work item: LongerTask4, Result: 11
+Work item: VeryLongTask5, Result: 13
+Total items processed: 5
+```
+
+When you run the sample, you'll see output from both the worker and client processes:
+
+### Worker Output
+The worker shows:
+- Registration of the orchestrator and activities
+- Log entries when each activity is called
+- Parallel processing of multiple work items
+- Final aggregation of results
+
+### Client Output
+The client shows:
+- Starting the orchestration with a list of work items
+- The unique orchestration instance ID
+- The final aggregated results, showing each work item and its corresponding result
+- Total count of processed items
+
+This demonstrates the power of the Fan-Out Fan-In pattern for parallel processing and result aggregation.
+
+## Reviewing the Orchestration in the Durable Task Scheduler Dashboard
+
+To access the Durable Task Scheduler Dashboard and review your orchestration:
+
+### Using the Emulator
+1. Navigate to http://localhost:8082 in your web browser
+2. Click on the "default" task hub
+3. You'll see the orchestration instance in the list
+4. Click on the instance ID to view the execution details, which will show:
+   - The parallel execution of multiple activity tasks
+   - The fan-in aggregation step
+   - The input and output at each step
+   - The time taken for each step
+
+### Using a Deployed Scheduler
+1. Navigate to the Scheduler resource in the Azure portal
+2. Go to the Task Hub subresource that you're using
+3. Click on the dashboard URL in the top right corner
+4. Search for your orchestration instance ID
+5. Review the execution details
+
+The dashboard visualizes the Fan-Out Fan-In pattern, making it easy to see how tasks are distributed in parallel and then aggregated back together.

--- a/samples/portable-sdks/dotnet/FanOutFanIn/Worker/ParallelProcessingOrchestration.cs
+++ b/samples/portable-sdks/dotnet/FanOutFanIn/Worker/ParallelProcessingOrchestration.cs
@@ -1,0 +1,93 @@
+using Microsoft.DurableTask;
+using Microsoft.Extensions.Logging;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+
+namespace FanOutFanIn;
+
+[DurableTask]
+public class ParallelProcessingOrchestration : TaskOrchestrator<List<string>, Dictionary<string, int>>
+{
+    public override async Task<Dictionary<string, int>> RunAsync(TaskOrchestrationContext context, List<string> workItems)
+    {
+        // Step 1: Fan-out by creating a task for each work item in parallel
+        List<Task<Dictionary<string, int>>> processingTasks = new List<Task<Dictionary<string, int>>>();
+        
+        foreach (string workItem in workItems)
+        {
+            // Create a task for each work item (fan-out)
+            Task<Dictionary<string, int>> task = context.CallActivityAsync<Dictionary<string, int>>(
+                nameof(ProcessWorkItemActivity), workItem);
+            processingTasks.Add(task);
+        }
+        
+        // Step 2: Wait for all parallel tasks to complete
+        Dictionary<string, int>[] results = await Task.WhenAll(processingTasks);
+        
+        // Step 3: Fan-in by aggregating all results
+        Dictionary<string, int> aggregatedResults = await context.CallActivityAsync<Dictionary<string, int>>(
+            nameof(AggregateResultsActivity), results);
+        
+        return aggregatedResults;
+    }
+}
+
+[DurableTask]
+public class ProcessWorkItemActivity : TaskActivity<string, Dictionary<string, int>>
+{
+    private readonly ILogger<ProcessWorkItemActivity> _logger;
+
+    public ProcessWorkItemActivity(ILogger<ProcessWorkItemActivity> logger)
+    {
+        _logger = logger;
+    }
+
+    public override Task<Dictionary<string, int>> RunAsync(TaskActivityContext context, string workItem)
+    {
+        _logger.LogInformation("Processing work item: {WorkItem}", workItem);
+        
+        // Simulate some work on the item
+        // This would be where you do the actual processing for each item
+        Dictionary<string, int> result = new Dictionary<string, int>
+        {
+            { workItem, workItem.Length } // Simple example: Count characters in the work item
+        };
+        
+        _logger.LogInformation("Completed processing work item: {WorkItem} with result: {Result}", 
+            workItem, result[workItem]);
+        
+        return Task.FromResult(result);
+    }
+}
+
+[DurableTask]
+public class AggregateResultsActivity : TaskActivity<Dictionary<string, int>[], Dictionary<string, int>>
+{
+    private readonly ILogger<AggregateResultsActivity> _logger;
+
+    public AggregateResultsActivity(ILogger<AggregateResultsActivity> logger)
+    {
+        _logger = logger;
+    }
+
+    public override Task<Dictionary<string, int>> RunAsync(TaskActivityContext context, Dictionary<string, int>[] results)
+    {
+        _logger.LogInformation("Aggregating {Count} results", results.Length);
+        
+        // Combine all the individual results into one aggregated result
+        Dictionary<string, int> aggregatedResult = new Dictionary<string, int>();
+        
+        foreach (Dictionary<string, int> result in results)
+        {
+            foreach (KeyValuePair<string, int> kvp in result)
+            {
+                // Merge each key-value pair into the aggregated result
+                aggregatedResult[kvp.Key] = kvp.Value;
+            }
+        }
+        
+        _logger.LogInformation("Aggregated {Count} work items into final result", aggregatedResult.Count);
+        
+        return Task.FromResult(aggregatedResult);
+    }
+}

--- a/samples/portable-sdks/dotnet/FanOutFanIn/Worker/Program.cs
+++ b/samples/portable-sdks/dotnet/FanOutFanIn/Worker/Program.cs
@@ -1,0 +1,86 @@
+using Azure.Identity;
+using Microsoft.DurableTask;
+using Microsoft.DurableTask.Worker;
+using Microsoft.DurableTask.Worker.AzureManaged;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Logging;
+using FanOutFanIn;
+
+// Configure the host builder
+HostApplicationBuilder builder = Host.CreateApplicationBuilder();
+
+// Configure logging
+builder.Logging.AddConsole();
+builder.Logging.SetMinimumLevel(LogLevel.Information);
+
+// Build a logger for startup configuration
+using ILoggerFactory loggerFactory = LoggerFactory.Create(loggingBuilder =>
+{
+    loggingBuilder.AddConsole();
+    loggingBuilder.SetMinimumLevel(LogLevel.Information);
+});
+ILogger<Program> logger = loggerFactory.CreateLogger<Program>();
+
+// Get environment variables for endpoint and taskhub with defaults
+string endpoint = Environment.GetEnvironmentVariable("ENDPOINT") ?? "http://localhost:8080";
+string taskHubName = Environment.GetEnvironmentVariable("TASKHUB") ?? "default";
+
+// Split the endpoint if it contains authentication info
+string hostAddress = endpoint;
+if (endpoint.Contains(';'))
+{
+    hostAddress = endpoint.Split(';')[0];
+}
+
+// Determine if we're connecting to the local emulator
+bool isLocalEmulator = endpoint == "http://localhost:8080";
+
+// Construct a proper connection string with authentication
+string connectionString;
+if (isLocalEmulator)
+{
+    // For local emulator, no authentication needed
+    connectionString = $"Endpoint={hostAddress};TaskHub={taskHubName};Authentication=None";
+    logger.LogInformation("Using local emulator with no authentication");
+}
+else
+{
+    // For Azure, use DefaultAzureCredential
+    connectionString = $"Endpoint={hostAddress};TaskHub={taskHubName};Authentication=DefaultAzureCredential";
+    logger.LogInformation("Using Azure endpoint with DefaultAzureCredential");
+}
+
+logger.LogInformation("Using endpoint: {Endpoint}", endpoint);
+logger.LogInformation("Using task hub: {TaskHubName}", taskHubName);
+logger.LogInformation("Host address: {HostAddress}", hostAddress);
+logger.LogInformation("Connection string: {ConnectionString}", connectionString);
+logger.LogInformation("This worker implements a Fan-Out Fan-In pattern for parallel processing of work items");
+
+// Configure services
+builder.Services.AddDurableTaskWorker()
+    .AddTasks(registry =>
+    {
+        // Manually register the orchestration and activity classes
+        registry.AddOrchestrator<ParallelProcessingOrchestration>();
+        registry.AddActivity<ProcessWorkItemActivity>();
+        registry.AddActivity<AggregateResultsActivity>();
+    })
+    .UseDurableTaskScheduler(connectionString);
+
+// Build the host
+IHost host = builder.Build();
+
+// Get the logger from the service provider for the rest of the program
+logger = host.Services.GetRequiredService<ILogger<Program>>();
+
+logger.LogInformation("Starting Fan-Out Fan-In Pattern - Parallel Processing Worker");
+
+// Start the host
+await host.StartAsync();
+
+logger.LogInformation("Worker started. Press any key to stop...");
+Console.ReadKey(); // Keep console ReadKey for interactive input
+
+// Stop the host
+await host.StopAsync();

--- a/samples/portable-sdks/dotnet/FanOutFanIn/Worker/Worker.csproj
+++ b/samples/portable-sdks/dotnet/FanOutFanIn/Worker/Worker.csproj
@@ -1,0 +1,19 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>net8.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Azure.Identity" Version="1.13.1" />
+    <PackageReference Include="Grpc.Net.Client" Version="2.67.0" />    
+    <PackageReference Include="Microsoft.DurableTask.Worker.AzureManaged" Version="1.8.1-preview.1" />
+    <PackageReference Include="Microsoft.DurableTask.Generators" Version="1.0.0-preview.1" OutputItemType="Analyzer" />
+    <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="8.0.1" />
+    <PackageReference Include="Microsoft.Extensions.Hosting" Version="8.0.0" />
+  </ItemGroup>
+
+</Project>

--- a/samples/portable-sdks/dotnet/FanOutFanIn/Worker/Worker.csproj
+++ b/samples/portable-sdks/dotnet/FanOutFanIn/Worker/Worker.csproj
@@ -10,7 +10,7 @@
   <ItemGroup>
     <PackageReference Include="Azure.Identity" Version="1.13.1" />
     <PackageReference Include="Grpc.Net.Client" Version="2.67.0" />    
-    <PackageReference Include="Microsoft.DurableTask.Worker.AzureManaged" Version="1.8.1-preview.1" />
+    <PackageReference Include="Microsoft.DurableTask.Worker.AzureManaged" Version="1.10.0-preview.1" />
     <PackageReference Include="Microsoft.DurableTask.Generators" Version="1.0.0-preview.1" OutputItemType="Analyzer" />
     <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="8.0.1" />
     <PackageReference Include="Microsoft.Extensions.Hosting" Version="8.0.0" />

--- a/samples/portable-sdks/dotnet/FunctionChaining/Client/Client.csproj
+++ b/samples/portable-sdks/dotnet/FunctionChaining/Client/Client.csproj
@@ -9,7 +9,7 @@
   <ItemGroup>
     <PackageReference Include="Azure.Identity" Version="1.13.1" />
     <PackageReference Include="Grpc.Net.Client" Version="2.67.0" />
-    <PackageReference Include="Microsoft.DurableTask.Client.AzureManaged" Version="1.8.1-preview.1" />
+    <PackageReference Include="Microsoft.DurableTask.Client.AzureManaged" Version="1.10.0-preview.1" />
     <PackageReference Include="Microsoft.DurableTask.Generators" Version="1.0.0-preview.1" OutputItemType="Analyzer" />
     <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="8.0.1" />
   </ItemGroup>

--- a/samples/portable-sdks/dotnet/FunctionChaining/Worker/Worker.csproj
+++ b/samples/portable-sdks/dotnet/FunctionChaining/Worker/Worker.csproj
@@ -10,7 +10,7 @@
   <ItemGroup>
     <PackageReference Include="Azure.Identity" Version="1.13.1" />
     <PackageReference Include="Grpc.Net.Client" Version="2.67.0" />    
-    <PackageReference Include="Microsoft.DurableTask.Worker.AzureManaged" Version="1.8.1-preview.1" />
+    <PackageReference Include="Microsoft.DurableTask.Worker.AzureManaged" Version="1.10.0-preview.1" />
     <PackageReference Include="Microsoft.DurableTask.Generators" Version="1.0.0-preview.1" OutputItemType="Analyzer" />
     <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="8.0.1" />
     <PackageReference Include="Microsoft.Extensions.Hosting" Version="8.0.0" />

--- a/samples/portable-sdks/dotnet/ScheduleWebApp/ScheduleWebApp.csproj
+++ b/samples/portable-sdks/dotnet/ScheduleWebApp/ScheduleWebApp.csproj
@@ -16,8 +16,8 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.DurableTask.Client.AzureManaged" Version="1.8.1-preview.1" />
-    <PackageReference Include="Microsoft.DurableTask.Worker.AzureManaged" Version="1.8.1-preview.1" />
-    <PackageReference Include="Microsoft.DurableTask.ScheduledTasks" Version="1.8.1-preview.1" />
+    <PackageReference Include="Microsoft.DurableTask.Client.AzureManaged" Version="1.10.0-preview.1" />
+    <PackageReference Include="Microsoft.DurableTask.Worker.AzureManaged" Version="1.10.0-preview.1" />
+    <PackageReference Include="Microsoft.DurableTask.ScheduledTasks" Version="1.10.0-preview.1" />
   </ItemGroup>
 </Project>


### PR DESCRIPTION
Adding a fanout-fanin example that uses the .NET Portable SDK. This simple example follows a similar scenario to the other example (Python fanout-fanin) and defaults to using the DTS emulator.