### PR TITLE
fix java samples hanging issue due to non daemon threads not cleanup (safe exit) + fix human in loop sample

### DIFF
--- a/samples/durable-task-sdks/java/function-chaining/src/main/java/io/durabletask/samples/ChainingPattern.java
+++ b/samples/durable-task-sdks/java/function-chaining/src/main/java/io/durabletask/samples/ChainingPattern.java
@@ -99,5 +99,6 @@ final class ChainingPattern {
 
         // Shutdown the worker and exit
         worker.stop();
+        System.exit(0);
     }
 }

--- a/samples/durable-task-sdks/java/human-interaction/src/main/java/io/durabletask/samples/HumanInteraction.java
+++ b/samples/durable-task-sdks/java/human-interaction/src/main/java/io/durabletask/samples/HumanInteraction.java
@@ -21,7 +21,7 @@ import java.util.logging.Logger;
  */
 public class HumanInteraction {
     private static final String ORCHESTRATION_NAME = "ApprovalWorkflow";
-    private static final Duration TIMEOUT = Duration.ofMinutes(1); // Short timeout for demo
+    private static final Duration TIMEOUT = Duration.ofHours(1); // Changed from 1 minute to 1 hour
     private static final Logger logger = Logger.getLogger(HumanInteraction.class.getName());
 
     public static void main(String[] args) throws IOException, InterruptedException, TimeoutException {
@@ -102,6 +102,7 @@ public class HumanInteraction {
 
         } finally {
             worker.stop();
+            System.exit(0);
         }
     }
 
@@ -130,7 +131,7 @@ public class HumanInteraction {
                         
                         // Wait for either approval or timeout
                         Task<?> winner = ctx.anyOf(approvalTask, timeoutTask).await();
-
+                        
                         if (winner == approvalTask) {
                             ApprovalResponse response = approvalTask.await();  // safe because we checked
                             String status = response.isApproved ? "APPROVED" : "REJECTED";

--- a/samples/durable-task-sdks/java/monitoring/src/main/java/io/durabletask/samples/MonitoringPattern.java
+++ b/samples/durable-task-sdks/java/monitoring/src/main/java/io/durabletask/samples/MonitoringPattern.java
@@ -116,6 +116,7 @@ public class MonitoringPattern {
             
         } finally {
             worker.stop();
+            System.exit(0);
         }
     }
 

--- a/samples/durable-task-sdks/java/sub-orchestrations/src/main/java/io/durabletask/samples/SubOrchestrationPattern.java
+++ b/samples/durable-task-sdks/java/sub-orchestrations/src/main/java/io/durabletask/samples/SubOrchestrationPattern.java
@@ -79,6 +79,7 @@ public class SubOrchestrationPattern {
             
         } finally {
             worker.stop();
+            System.exit(0);
         }
     }
 


### PR DESCRIPTION
This pull request introduces several changes across multiple Java sample files in the `durable-task-sdks` directory. The changes primarily focus on ensuring proper application termination and adjusting the timeout duration for a specific workflow. Below is a summary of the most important changes:

### Application Termination Improvements:
* Added `System.exit(0);` after stopping the worker to ensure proper application termination in the following files:
  - `ChainingPattern.java` (`create` method)
  - `HumanInteraction.java` (`main` method)
  - `MonitoringPattern.java` (`main` method)
  - `SubOrchestrationPattern.java` (`main` method)

### Workflow Timeout Adjustment:
* Increased the timeout duration for the `ApprovalWorkflow` orchestration in `HumanInteraction.java` from 1 minute to 1 hour for better usability in real-world scenarios.## Purpose
<!-- Describe the intention of the changes being proposed. What problem does it solve or functionality does it add? -->
* ...

## Does this introduce a breaking change?
<!-- Mark one with an "x". -->
```
[ ] Yes
[ ] No
```

## Pull Request Type
What kind of change does this Pull Request introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[ ] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Documentation content changes
[ ] Other... Please describe:
```

## How to Test
*  Get the code

```
git clone [repo-address]
cd [repo-name]
git checkout [branch-name]
npm install
```

* Test the code
<!-- Add steps to run the tests suite and/or manually test -->
```
```

## What to Check
Verify that the following are valid
* ...

## Other Information
<!-- Add any other helpful information that may be needed here. -->