### PR TITLE
Added conditional logging for child orchestration completion in SubOrchestrationPattern to avoid logging during replay.

### DIFF
--- a/samples/durable-task-sdks/java/sub-orchestrations/src/main/java/io/durabletask/samples/SubOrchestrationPattern.java
+++ b/samples/durable-task-sdks/java/sub-orchestrations/src/main/java/io/durabletask/samples/SubOrchestrationPattern.java
@@ -114,7 +114,9 @@ public class SubOrchestrationPattern {
                                 childInput,
                                 String.class).await();
                             
-                            logger.info("Child orchestration " + (i + 1) + " completed with ID: " + childId);
+                            if (!ctx.getIsReplaying()) {
+                                logger.info("Child orchestration " + (i + 1) + " completed with ID: " + childId);
+                            }
                             totalChildren++;
                             
                             // Update status


### PR DESCRIPTION
## Purpose
<!-- Describe the intention of the changes being proposed. What problem does it solve or functionality does it add? -->
* ...
This pull request introduces a minor improvement to the `SubOrchestrationPattern.java` file by adding a conditional check to prevent logging during replay.

Enhancements to logging:

* [`samples/durable-task-sdks/java/sub-orchestrations/src/main/java/io/durabletask/samples/SubOrchestrationPattern.java`](diffhunk://#diff-7ba385c3ae101c165254487acc171801a333ba258d55a94711b9e1e25b2a27ecR118-R120): Added a check using `ctx.getIsReplaying()` to ensure that the log statement for completed child orchestrations is only executed when the orchestration is not replaying.
## Does this introduce a breaking change?
<!-- Mark one with an "x". -->
```
[ ] Yes
[ ] No
```

## Pull Request Type
What kind of change does this Pull Request introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[ ] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Documentation content changes
[ ] Other... Please describe:
```

## How to Test
*  Get the code

```
git clone [repo-address]
cd [repo-name]
git checkout [branch-name]
npm install
```

* Test the code
<!-- Add steps to run the tests suite and/or manually test -->
```
```

## What to Check
Verify that the following are valid
* ...

## Other Information
<!-- Add any other helpful information that may be needed here. -->