### PR TITLE
Addressed bugbash feedback and standardized readme

### DIFF
--- a/quickstarts/durable-functions/dotnet/HelloCities/scripts/deploy.sh
+++ b/quickstarts/durable-functions/dotnet/HelloCities/scripts/deploy.sh
@@ -52,7 +52,7 @@ az storage account network-rule add \
 
 # Give some time for the rule to take effect
 echo "Waiting for network rules to apply..."
-sleep 10
+sleep 15
 
 # Upload the zip package to Azure Storage Blob container
 echo "Uploading functions.zip to Azure Storage Blob container $AZURE_STORAGE_ACCOUNT_NAME/$AZURE_STORAGE_CONTAINER_NAME/$zipFileName..."

--- a/samples/durable-functions/dotnet/OrderProcessor/scripts/deploy.ps1
+++ b/samples/durable-functions/dotnet/OrderProcessor/scripts/deploy.ps1
@@ -53,7 +53,7 @@ az storage account network-rule add `
 
 # Give some time for the rule to take effect
 Write-Output "Waiting for network rules to apply..."
-Start-Sleep -Seconds 10
+Start-Sleep -Seconds 15
 
 # Upload the zip package to Azure Storage Blob container
 Write-Output "Uploading functions.zip to Azure Storage Blob container $env:AZURE_STORAGE_ACCOUNT_NAME/$env:AZURE_STORAGE_CONTAINER_NAME/$zipFileName..."

--- a/samples/durable-functions/dotnet/OrderProcessor/scripts/deploy.sh
+++ b/samples/durable-functions/dotnet/OrderProcessor/scripts/deploy.sh
@@ -52,7 +52,7 @@ az storage account network-rule add \
 
 # Give some time for the rule to take effect
 echo "Waiting for network rules to apply..."
-sleep 10
+sleep 15
 
 # Upload the zip package to Azure Storage Blob container
 echo "Uploading functions.zip to Azure Storage Blob container $AZURE_STORAGE_ACCOUNT_NAME/$AZURE_STORAGE_CONTAINER_NAME/$zipFileName..."

--- a/samples/durable-task-sdks/dotnet/AspNetWebApp/README.md
+++ b/samples/durable-task-sdks/dotnet/AspNetWebApp/README.md
@@ -13,7 +13,7 @@ This directory includes a sample .NET console app that demonstrates how to use t
 
 ## Configuring Durable Task Scheduler
 
-There are two ways to run this sample:
+There are two ways to run this sample locally: locally:
 
 ### Using the Emulator (Recommended)
 

--- a/samples/durable-task-sdks/dotnet/AspNetWebApp/README.md
+++ b/samples/durable-task-sdks/dotnet/AspNetWebApp/README.md
@@ -8,12 +8,36 @@ This directory includes a sample .NET console app that demonstrates how to use t
 
 - [.NET 8 SDK](https://dotnet.microsoft.com/download/dotnet/8.0)
 - [Azure CLI](https://docs.microsoft.com/cli/azure/install-azure-cli)
+- [Docker](https://www.docker.com/products/docker-desktop/) (for running the emulator) installed
 
-## Creating a durable task scheduler task hub
 
-Before you can run the app, you need to create a durable task scheduler task hub in Azure.
+## Configuring Durable Task Scheduler
 
-> **NOTE**: These are abbreviated instructions for simplicity. For a full set of instructions, see the Azure Durable Functions [QuickStart guide](../../../../quickstarts/durable-functions/dotnet/HelloCities/README.md).
+There are two ways to run this sample:
+
+### Using the Emulator (Recommended)
+
+The emulator simulates a scheduler and taskhub in a Docker container, making it ideal for development and learning.
+
+1. Pull the Docker Image for the Emulator:
+    ```bash
+    docker pull mcr.microsoft.com/dts/dts-emulator:latest
+    ```
+
+1. Run the Emulator:
+    ```bash
+    docker run -it -p 8080:8080 -p 8082:8082 mcr.microsoft.com/dts/dts-emulator:latest
+    ```
+    Wait a few seconds for the container to be ready.
+
+1. Set the scheduler connection string:
+    ```bash
+    export DURABLE_TASK_SCHEDULER_CONNECTION_STRING="Endpoint=http://localhost:8080;TaskHub=default;Authentication=None"
+    ```
+
+### Using a Deployed Scheduler and Taskhub in Azure
+
+Local development with a deployed scheduler:
 
 1. Install the durable task scheduler CLI extension:
 
@@ -22,26 +46,17 @@ Before you can run the app, you need to create a durable task scheduler task hub
     az extension add --name durabletask --allow-preview true
     ```
 
-1. Create a resource group:
+1. Create a resource group in a region where the Durable Task Scheduler is available:
 
     ```bash
-    az group create --name my-resource-group --location northcentralus
+    az provider show --namespace Microsoft.DurableTask --query "resourceTypes[?resourceType=='schedulers'].locations | [0]" --out table
+    ```
+
+    ```bash
+    az group create --name my-resource-group --location <location>
     ```
 
 1. Create a durable task scheduler resource:
-
-    **PowerShell**:
-
-    ```powershell
-    az durabletask scheduler create `
-        --resource-group my-resource-group `
-        --name my-scheduler `
-        --ip-allowlist '["0.0.0.0/0"]' `
-        --sku-name "Dedicated" `
-        --sku-capacity 1
-    ```
-
-    **Bash**:
 
     ```bash
     az durabletask scheduler create \
@@ -49,44 +64,20 @@ Before you can run the app, you need to create a durable task scheduler task hub
         --name my-scheduler \
         --ip-allowlist '["0.0.0.0/0"]' \
         --sku-name "Dedicated" \
-        --sku-capacity 1
+        --sku-capacity 1 \
+        --tags "{'myattribute':'myvalue'}"
     ```
 
 1. Create a task hub within the scheduler resource:
-
-    **PowerShell**:
-
-    ```powershell
-    az durabletask taskhub create `
-        --resource-group my-resource-group `
-        --scheduler-name my-scheduler `
-        --name "durable-task-dotnet"
-    ```
-
-    **Bash**:
 
     ```bash
     az durabletask taskhub create \
         --resource-group my-resource-group \
         --scheduler-name my-scheduler \
-        --name "durable-task-dotnet"
+        --name "my-taskhub"
     ```
 
-1. Grant the current user permission to connect to the `durable-task-dotnet` task hub:
-
-    **PowerShell**:
-
-    ```powershell
-    $subscriptionId = az account show --query "id" -o tsv
-    $loggedInUser = az account show --query "user.name" -o tsv
-
-    az role assignment create `
-        --assignee $loggedInUser `
-        --role "Durable Task Data Contributor" `
-        --scope "/subscriptions/$subscriptionId/resourceGroups/my-resource-group/providers/Microsoft.DurableTask/schedulers/my-scheduler/taskHubs/durable-task-dotnet"
-    ```
-
-    **Bash**:
+1. Grant the current user permission to connect to the `my-taskhub` task hub:
 
     ```bash
     subscriptionId=$(az account show --query "id" -o tsv)
@@ -95,26 +86,12 @@ Before you can run the app, you need to create a durable task scheduler task hub
     az role assignment create \
         --assignee $loggedInUser \
         --role "Durable Task Data Contributor" \
-        --scope "/subscriptions/$subscriptionId/resourceGroups/my-resource-group/providers/Microsoft.DurableTask/schedulers/my-scheduler/taskHubs/durable-task-dotnet"
+        --scope "/subscriptions/$subscriptionId/resourceGroups/my-resource-group/providers/Microsoft.DurableTask/schedulers/my-scheduler/taskHubs/my-taskhub"
     ```
 
     Note that it may take a minute for the role assignment to take effect.
 
 1. Generate a connection string for the scheduler and task hub resources and save it to the `DURABLE_TASK_SCHEDULER_CONNECTION_STRING` environment variable:
-
-    **PowerShell**:
-
-    ```powershell
-    $endpoint = az durabletask scheduler show `
-        --resource-group my-resource-group `
-        --name my-scheduler `
-        --query "properties.endpoint" `
-        --output tsv
-    $taskhub = "durable-task-dotnet"
-    $env:DURABLE_TASK_SCHEDULER_CONNECTION_STRING = "Endpoint=$endpoint;TaskHub=$taskhub;Authentication=DefaultAzure"
-    ```
-
-    **Bash**:
 
     ```bash
     endpoint=$(az durabletask scheduler show \
@@ -122,7 +99,7 @@ Before you can run the app, you need to create a durable task scheduler task hub
         --name my-scheduler \
         --query "properties.endpoint" \
         --output tsv)
-    taskhub="durable-task-dotnet"
+    taskhub="my-taskhub"
     export DURABLE_TASK_SCHEDULER_CONNECTION_STRING="Endpoint=$endpoint;TaskHub=$taskhub;Authentication=DefaultAzure"
     ```
 
@@ -130,7 +107,7 @@ Before you can run the app, you need to create a durable task scheduler task hub
 
 ## Running the sample
 
-In the same terminal window as above, use the following steps to run the sample on your local machine.
+Once you have set up either the emulator or deployed scheduler, follow these steps to run the sample:
 
 1. Clone this repository.
 
@@ -169,25 +146,11 @@ You can view the orchestrations in the Durable Task Scheduler dashboard by navig
 
 Use the following PowerShell command from a new terminal window to get the dashboard URL:
 
-**PowerShell**:
-
-```powershell
-$dashboardUrl = az durabletask taskhub show `
-    --resource-group "my-resource-group" `
-    --scheduler-name "my-scheduler" `
-    --name "durable-task-dotnet" `
-    --query "properties.dashboardUrl" `
-    --output tsv
-$dashboardUrl
-```
-
-**Bash**:
-
 ```bash
 dashboardUrl=$(az durabletask taskhub show \
     --resource-group "my-resource-group" \
     --scheduler-name "my-scheduler" \
-    --name "durable-task-dotnet" \
+    --name "my-taskhub" \
     --query "properties.dashboardUrl" \
     --output tsv)
 echo $dashboardUrl
@@ -196,7 +159,7 @@ echo $dashboardUrl
 The URL should look something like the following:
 
 ```plaintext
-https://dashboard.durabletask.io/subscriptions/{subscriptionID}/schedulers/my-scheduler/taskhubs/durable-task-dotnet?endpoint=https%3a%2f%2fmy-scheduler-gvdmebc6dmdj.northcentralus.durabletask.io
+https://dashboard.durabletask.io/subscriptions/{subscriptionID}/schedulers/my-scheduler/taskhubs/my-taskhub?endpoint=https%3a%2f%2fmy-scheduler-gvdmebc6dmdj.northcentralus.durabletask.io
 ```
 
 Once logged in, you should see the orchestrations that were created by the sample app. Below is an example of what the dashboard might look like (note that some of the details will be different than the screenshot):
@@ -206,8 +169,8 @@ Once logged in, you should see the orchestrations that were created by the sampl
 ## Optional: Deploy to Azure Container Apps
 
 1. Create an container app following the instructions in the [Azure Container App documentation](https://learn.microsoft.com/azure/container-apps/quickstart-code-to-cloud?tabs=bash%2Ccsharp).
-1. During step 1, specify the deployed container app code folder at samples\durable-task-sdks\dotnet\AspNetWebApp
-1. Create a user managed identity in Azure and assign the `Durable Task Data Contributor` role to it. Then attach this managed identity to the container app you created in step 1. Please use the Azure CLI or Azure Portal to set this up. For detailed instructions, see the [Azure Container Apps managed identities documentation](https://learn.microsoft.com/en-us/azure/container-apps/managed-identity).
+1. During step 1, specify the deployed container app code folder at samples/durable-task-sdks/dotnet/AspNetWebApp
+1. Create a user managed identity in Azure and assign the `Durable Task Data Contributor` role to it. Then attach this managed identity to the container app you created in step 1. Please use the Azure CLI or Azure Portal to set this up. For detailed instructions, see the [Azure Container Apps managed identities documentation](https://learn.microsoft.com/azure/container-apps/managed-identity).
 1. Call the container app endpoint at `http://sampleapi-<your-container-app-name>.azurecontainerapps.io/scenarios/hellocities?count=10`, Sample curl command:
 
     ```bash

--- a/samples/durable-task-sdks/dotnet/AspNetWebApp/README.md
+++ b/samples/durable-task-sdks/dotnet/AspNetWebApp/README.md
@@ -60,7 +60,7 @@ Before you can run the app, you need to create a durable task scheduler task hub
     az durabletask taskhub create `
         --resource-group my-resource-group `
         --scheduler-name my-scheduler `
-        --name "portable-dotnet"
+        --name "durable-task-dotnet"
     ```
 
     **Bash**:
@@ -69,10 +69,10 @@ Before you can run the app, you need to create a durable task scheduler task hub
     az durabletask taskhub create \
         --resource-group my-resource-group \
         --scheduler-name my-scheduler \
-        --name "portable-dotnet"
+        --name "durable-task-dotnet"
     ```
 
-1. Grant the current user permission to connect to the `portable-dotnet` task hub:
+1. Grant the current user permission to connect to the `durable-task-dotnet` task hub:
 
     **PowerShell**:
 
@@ -83,7 +83,7 @@ Before you can run the app, you need to create a durable task scheduler task hub
     az role assignment create `
         --assignee $loggedInUser `
         --role "Durable Task Data Contributor" `
-        --scope "/subscriptions/$subscriptionId/resourceGroups/my-resource-group/providers/Microsoft.DurableTask/schedulers/my-scheduler/taskHubs/portable-dotnet"
+        --scope "/subscriptions/$subscriptionId/resourceGroups/my-resource-group/providers/Microsoft.DurableTask/schedulers/my-scheduler/taskHubs/durable-task-dotnet"
     ```
 
     **Bash**:
@@ -95,7 +95,7 @@ Before you can run the app, you need to create a durable task scheduler task hub
     az role assignment create \
         --assignee $loggedInUser \
         --role "Durable Task Data Contributor" \
-        --scope "/subscriptions/$subscriptionId/resourceGroups/my-resource-group/providers/Microsoft.DurableTask/schedulers/my-scheduler/taskHubs/portable-dotnet"
+        --scope "/subscriptions/$subscriptionId/resourceGroups/my-resource-group/providers/Microsoft.DurableTask/schedulers/my-scheduler/taskHubs/durable-task-dotnet"
     ```
 
     Note that it may take a minute for the role assignment to take effect.
@@ -110,7 +110,7 @@ Before you can run the app, you need to create a durable task scheduler task hub
         --name my-scheduler `
         --query "properties.endpoint" `
         --output tsv
-    $taskhub = "portable-dotnet"
+    $taskhub = "durable-task-dotnet"
     $env:DURABLE_TASK_SCHEDULER_CONNECTION_STRING = "Endpoint=$endpoint;TaskHub=$taskhub;Authentication=DefaultAzure"
     ```
 
@@ -122,7 +122,7 @@ Before you can run the app, you need to create a durable task scheduler task hub
         --name my-scheduler \
         --query "properties.endpoint" \
         --output tsv)
-    taskhub="portable-dotnet"
+    taskhub="durable-task-dotnet"
     export DURABLE_TASK_SCHEDULER_CONNECTION_STRING="Endpoint=$endpoint;TaskHub=$taskhub;Authentication=DefaultAzure"
     ```
 
@@ -175,7 +175,7 @@ Use the following PowerShell command from a new terminal window to get the dashb
 $dashboardUrl = az durabletask taskhub show `
     --resource-group "my-resource-group" `
     --scheduler-name "my-scheduler" `
-    --name "portable-dotnet" `
+    --name "durable-task-dotnet" `
     --query "properties.dashboardUrl" `
     --output tsv
 $dashboardUrl
@@ -187,7 +187,7 @@ $dashboardUrl
 dashboardUrl=$(az durabletask taskhub show \
     --resource-group "my-resource-group" \
     --scheduler-name "my-scheduler" \
-    --name "portable-dotnet" \
+    --name "durable-task-dotnet" \
     --query "properties.dashboardUrl" \
     --output tsv)
 echo $dashboardUrl
@@ -196,7 +196,7 @@ echo $dashboardUrl
 The URL should look something like the following:
 
 ```plaintext
-https://dashboard.durabletask.io/subscriptions/{subscriptionID}/schedulers/my-scheduler/taskhubs/portable-dotnet?endpoint=https%3a%2f%2fmy-scheduler-gvdmebc6dmdj.northcentralus.durabletask.io
+https://dashboard.durabletask.io/subscriptions/{subscriptionID}/schedulers/my-scheduler/taskhubs/durable-task-dotnet?endpoint=https%3a%2f%2fmy-scheduler-gvdmebc6dmdj.northcentralus.durabletask.io
 ```
 
 Once logged in, you should see the orchestrations that were created by the sample app. Below is an example of what the dashboard might look like (note that some of the details will be different than the screenshot):

--- a/samples/durable-task-sdks/dotnet/AspNetWebApp/README.md
+++ b/samples/durable-task-sdks/dotnet/AspNetWebApp/README.md
@@ -13,7 +13,7 @@ This directory includes a sample .NET console app that demonstrates how to use t
 
 ## Configuring Durable Task Scheduler
 
-There are two ways to run this sample locally: locally:
+There are two ways to run this sample locally:
 
 ### Using the Emulator (Recommended)
 

--- a/samples/durable-task-sdks/dotnet/EntitiesSample/README.md
+++ b/samples/durable-task-sdks/dotnet/EntitiesSample/README.md
@@ -25,16 +25,14 @@ From a terminal window as above, use the following steps to run the sample on yo
     ```
 
     ```bash
-    docker run -itP mcr.microsoft.com/dts/dts-emulator:latest
+    docker run -d -p 8080:8080 -p 8082:8082 mcr.microsoft.com/dts/dts-emulator:latest    
     ```
 
 1. Set the `DURABLE_TASK_SCHEDULER_CONNECTION_STRING` environment variable:
 
     ```bash
-    export DURABLE_TASK_SCHEDULER_CONNECTION_STRING="Endpoint=http://localhost:<port number>;TaskHub=default;Authentication=None"
+    export DURABLE_TASK_SCHEDULER_CONNECTION_STRING="Endpoint=http://localhost:8080;TaskHub=default;Authentication=None"
     ```
-
-    The *port number* is the one mapped to port `8080` on Docker. 
 
 1. Run the following command to build and run the sample:
 
@@ -136,4 +134,4 @@ From a terminal window as above, use the following steps to run the sample on yo
 
 ## View orchestrations and entities in the dashboard
 
-You can view the sample's orchestrations and entities in the Durable Task Scheduler emulator's dashboard by navigating to `http://localhost:<port number>` (where *port number* is the one mapped to port 8082 in Docker) in your browser and selecting the `default` task hub.
+You can view the sample's orchestrations and entities in the Durable Task Scheduler emulator's dashboard by navigating to `http://localhost:8082` in your browser and selecting the `default` task hub.

--- a/samples/durable-task-sdks/dotnet/EntitiesSample/README.md
+++ b/samples/durable-task-sdks/dotnet/EntitiesSample/README.md
@@ -6,7 +6,7 @@ The [Durable Task SDK for .NET](https://github.com/microsoft/durabletask-dotnet)
 
 - [.NET 8 SDK](https://dotnet.microsoft.com/download/dotnet/8.0)
 - [Azure CLI](https://docs.microsoft.com/cli/azure/install-azure-cli)
-- [Docker](https://www.docker.com/get-started)
+- [Docker](https://www.docker.com/get-started) installed
 
 ## Running the sample with the Durable Task Scheduler Emulator
 

--- a/samples/durable-task-sdks/dotnet/FanOutFanIn/README.md
+++ b/samples/durable-task-sdks/dotnet/FanOutFanIn/README.md
@@ -21,7 +21,7 @@ This pattern is useful for:
 ## Prerequisites
 
 1. [.NET 8 SDK](https://dotnet.microsoft.com/download/dotnet/8.0) or later
-2. [Docker](https://www.docker.com/products/docker-desktop/) (for running the emulator)
+2. [Docker](https://www.docker.com/products/docker-desktop/) (for running the emulator) installed
 3. [Azure CLI](https://docs.microsoft.com/cli/azure/install-azure-cli) (if using a deployed Durable Task Scheduler)
 
 ## Configuring Durable Task Scheduler
@@ -47,25 +47,56 @@ Note: The example code automatically uses the default emulator settings (endpoin
 
 ### Using a Deployed Scheduler and Taskhub in Azure
 
-For production scenarios or when you're ready to deploy to Azure:
+Local development with a deployed scheduler:
 
-1. Create a Scheduler using the Azure CLI:
+1. Install the durable task scheduler CLI extension:
+
     ```bash
-    az durabletask scheduler create --resource-group <resource-group> --name <scheduler-name> --location <location> --ip-allowlist "[0.0.0.0/0]" --sku-capacity 1 --sku-name "Dedicated" --tags "{'myattribute':'myvalue'}"
+    az upgrade
+    az extension add --name durabletask --allow-preview true
     ```
 
-1. Create Your Taskhub:
+1. Create a resource group in a region where the Durable Task Scheduler is available:
+
     ```bash
-    az durabletask taskhub create --resource-group <resource-group> --scheduler-name <scheduler-name> --name <taskhub-name>
+    az provider show --namespace Microsoft.DurableTask --query "resourceTypes[?resourceType=='schedulers'].locations | [0]" --out table
     ```
 
-1. Assign your identity access to the task hub: 
     ```bash
-    assignee=$(az ad user show --id "someone@microsoft.com" --query "id" --output tsv)
+    az group create --name my-resource-group --location <location>
+    ```
 
-    scope="/subscriptions/<subscription-id>/resourceGroups/<resource-group>/providers/Microsoft.DurableTask/schedulers/<scheduler-name>/taskHubs/<taskhub-name>"
+1. Create a durable task scheduler resource:
 
-    az role assignment create --assignee "$assignee" --role "Durable Task Data Contributor" --scope "$scope"
+    ```bash
+    az durabletask scheduler create \
+        --resource-group my-resource-group \
+        --name my-scheduler \
+        --ip-allowlist '["0.0.0.0/0"]' \
+        --sku-name "Dedicated" \
+        --sku-capacity 1 \
+        --tags "{'myattribute':'myvalue'}"
+    ```
+
+1. Create a task hub within the scheduler resource:
+
+    ```bash
+    az durabletask taskhub create \
+        --resource-group my-resource-group \
+        --scheduler-name my-scheduler \
+        --name "my-taskhub"
+    ```
+
+1. Grant the current user permission to connect to the `my-taskhub` task hub:
+
+    ```bash
+    subscriptionId=$(az account show --query "id" -o tsv)
+    loggedInUser=$(az account show --query "user.name" -o tsv)
+
+    az role assignment create \
+        --assignee $loggedInUser \
+        --role "Durable Task Data Contributor" \
+        --scope "/subscriptions/$subscriptionId/resourceGroups/my-resource-group/providers/Microsoft.DurableTask/schedulers/my-scheduler/taskHubs/my-taskhub"
     ```
 
 ## Authentication
@@ -73,7 +104,7 @@ For production scenarios or when you're ready to deploy to Azure:
 The sample includes smart detection of the environment and configures authentication automatically:
 
 - For local development with the emulator (when endpoint is http://localhost:8080), no authentication is required.
-- For Azure deployments, DefaultAzure authentication is used, which utilizes DefaultAzureCredential behind the scenes and tries multiple authentication methods:
+- For local development with a deployed scheduler, DefaultAzure authentication is used, which utilizes DefaultAzureCredential behind the scenes and tries multiple authentication methods:
   - Managed Identity
   - Environment variables (AZURE_CLIENT_ID, AZURE_TENANT_ID, AZURE_CLIENT_SECRET)
   - Azure CLI login
@@ -85,7 +116,7 @@ The connection string is constructed dynamically based on the environment:
 // For local emulator
 connectionString = $"Endpoint={schedulerEndpoint};TaskHub={taskHubName};Authentication=None";
 
-// For Azure
+// For Azure deployed emulator
 connectionString = $"Endpoint={schedulerEndpoint};TaskHub={taskHubName};Authentication=DefaultAzure";
 ```
 
@@ -93,18 +124,15 @@ connectionString = $"Endpoint={schedulerEndpoint};TaskHub={taskHubName};Authenti
 
 Once you have set up either the emulator or deployed scheduler, follow these steps to run the sample:
 
-1.  If you're using a deployed scheduler, you need set Environment Variables. Note the scheduler endpoint can be found in the Scheduler's overview tab on Azure Portal.
-
-    Bash:
+1.  If you're using a deployed scheduler, you need to set Environment Variables:
     ```bash
-    export TASKHUB=<taskhubname>
-    export ENDPOINT=<schedulerEndpoint>
-    ```
+    export ENDPOINT=$(az durabletask scheduler show \
+        --resource-group my-resource-group \
+        --name my-scheduler \
+        --query "properties.endpoint" \
+        --output tsv)
 
-    PowerShell:
-    ```powershell
-    $env:TASKHUB = "<taskhubname>"
-    $env:ENDPOINT = "<schedulerEndpoint>"
+    export TASKHUB="my-taskhub"
     ```
 
 1. Start the worker in a terminal:
@@ -121,6 +149,10 @@ Once you have set up either the emulator or deployed scheduler, follow these ste
     cd samples/durable-task-sdks/dotnet/FanOutFanIn/Client
     dotnet run
     ```
+
+## Identity-based authentication
+
+Learn how to set up [identity-based authentication](https://learn.microsoft.com/azure/azure-functions/durable/durable-task-scheduler/durable-task-scheduler-identity?tabs=df&pivots=az-cli) when you deploy the app Azure.  
 
 ## Understanding the Code Structure
 

--- a/samples/durable-task-sdks/dotnet/FanOutFanIn/README.md
+++ b/samples/durable-task-sdks/dotnet/FanOutFanIn/README.md
@@ -26,7 +26,7 @@ This pattern is useful for:
 
 ## Configuring Durable Task Scheduler
 
-There are two ways to run this sample locally: locally:
+There are two ways to run this sample locally:
 
 ### Using the Emulator (Recommended)
 

--- a/samples/durable-task-sdks/dotnet/FanOutFanIn/README.md
+++ b/samples/durable-task-sdks/dotnet/FanOutFanIn/README.md
@@ -26,7 +26,7 @@ This pattern is useful for:
 
 ## Configuring Durable Task Scheduler
 
-There are two ways to run this sample:
+There are two ways to run this sample locally: locally:
 
 ### Using the Emulator (Recommended)
 

--- a/samples/durable-task-sdks/dotnet/FunctionChaining/README.md
+++ b/samples/durable-task-sdks/dotnet/FunctionChaining/README.md
@@ -19,7 +19,7 @@ This pattern is useful for:
 ## Prerequisites
 
 1. [.NET 8 SDK](https://dotnet.microsoft.com/download/dotnet/8.0) or later
-2. [Docker](https://www.docker.com/products/docker-desktop/) (for running the emulator)
+2. [Docker](https://www.docker.com/products/docker-desktop/) (for running the emulator) installed
 3. [Azure CLI](https://docs.microsoft.com/cli/azure/install-azure-cli) (if using a deployed Durable Task Scheduler)
 
 ## Configuring Durable Task Scheduler
@@ -45,25 +45,54 @@ Note: The example code automatically uses the default emulator settings (endpoin
 
 ### Using a Deployed Scheduler and Taskhub in Azure
 
-For production scenarios or when you're ready to deploy to Azure:
+1. Install the durable task scheduler CLI extension:
 
-1. Create a Scheduler using the Azure CLI:
-   ```bash
-   az durabletask scheduler create --resource-group <testrg> --name <testscheduler> --location <eastus> --ip-allowlist "[0.0.0.0/0]" --sku-capacity 1 --sku-name "Dedicated" --tags "{'myattribute':'myvalue'}"
-   ```
-
-1. Create Your Taskhub:
-   ```bash
-   az durabletask taskhub create --resource-group <testrg> --scheduler-name <testscheduler> --name <testtaskhub>
-   ```
-
-1. Assign your identity access to the task hub: 
     ```bash
-    assignee=$(az ad user show --id "someone@microsoft.com" --query "id" --output tsv)
+    az upgrade
+    az extension add --name durabletask --allow-preview true
+    ```
 
-    scope="/subscriptions/<subscription-id>/resourceGroups/<resource-group>/providers/Microsoft.DurableTask/schedulers/<scheduler-name>/taskHubs/<taskhub-name>"
+1. Create a resource group in a region where the Durable Task Scheduler is available:
 
-    az role assignment create --assignee "$assignee" --role "Durable Task Data Contributor" --scope "$scope"
+    ```bash
+    az provider show --namespace Microsoft.DurableTask --query "resourceTypes[?resourceType=='schedulers'].locations | [0]" --out table
+    ```
+
+    ```bash
+    az group create --name my-resource-group --location <location>
+    ```
+
+1. Create a durable task scheduler resource:
+
+    ```bash
+    az durabletask scheduler create \
+        --resource-group my-resource-group \
+        --name my-scheduler \
+        --ip-allowlist '["0.0.0.0/0"]' \
+        --sku-name "Dedicated" \
+        --sku-capacity 1 \
+        --tags "{'myattribute':'myvalue'}"
+    ```
+
+1. Create a task hub within the scheduler resource:
+
+    ```bash
+    az durabletask taskhub create \
+        --resource-group my-resource-group \
+        --scheduler-name my-scheduler \
+        --name "my-taskhub"
+    ```
+
+1. Grant the current user permission to connect to the `my-taskhub` task hub:
+
+    ```bash
+    subscriptionId=$(az account show --query "id" -o tsv)
+    loggedInUser=$(az account show --query "user.name" -o tsv)
+
+    az role assignment create \
+        --assignee $loggedInUser \
+        --role "Durable Task Data Contributor" \
+        --scope "/subscriptions/$subscriptionId/resourceGroups/my-resource-group/providers/Microsoft.DurableTask/schedulers/my-scheduler/taskHubs/my-taskhub"
     ```
 
 ## Authentication
@@ -71,7 +100,7 @@ For production scenarios or when you're ready to deploy to Azure:
 The sample includes smart detection of the environment and configures authentication automatically:
 
 - For local development with the emulator (when endpoint is http://localhost:8080), no authentication is required.
-- For Azure deployments, DefaultAzureCredential is used, which tries multiple authentication methods:
+- For local development with a deployed scheduler, DefaultAzure authentication is used, which utilizes DefaultAzureCredential behind the scenes and tries multiple authentication methods:
   - Managed Identity
   - Environment variables (AZURE_CLIENT_ID, AZURE_TENANT_ID, AZURE_CLIENT_SECRET)
   - Azure CLI login
@@ -83,7 +112,7 @@ The connection string is constructed dynamically based on the environment:
 // For local emulator
 connectionString = $"Endpoint={schedulerEndpoint};TaskHub={taskHubName};Authentication=None";
 
-// For Azure
+// For Azure deployed emulator
 connectionString = $"Endpoint={schedulerEndpoint};TaskHub={taskHubName};Authentication=DefaultAzure";
 ```
 
@@ -91,36 +120,31 @@ connectionString = $"Endpoint={schedulerEndpoint};TaskHub={taskHubName};Authenti
 
 Once you have set up either the emulator or deployed scheduler, follow these steps to run the sample:
 
-### Local Development
-
-1.  If you're using a deployed scheduler, you need set Environment Variables. Note the scheduler endpoint can be found in the Scheduler's overview tab on Azure Portal.
-
-    Bash:
+1.  If you're using a deployed scheduler, you need set Environment Variables.
     ```bash
-    export TASKHUB=<taskhubname>
-    export ENDPOINT=<schedulerEndpoint>
+    export ENDPOINT=$(az durabletask scheduler show \
+        --resource-group my-resource-group \
+        --name my-scheduler \
+        --query "properties.endpoint" \
+        --output tsv)
+
+    export TASKHUB="my-taskhub"
     ```
 
-    PowerShell:
-    ```powershell
-    $env:TASKHUB = "<taskhubname>"
-    $env:ENDPOINT = "<schedulerEndpoint>"
+1. Start the worker in a terminal:
+    ```bash
+    cd samples/durable-task-sdks/dotnet/FunctionChaining/Worker
+    dotnet run
     ```
+    You should see output indicating the worker has started and registered the orchestration and activities.
 
-1. First, start the Worker (processing component):
+1. In a new terminal, run the client:
+    > **Note:** Remember to set the environment variables again if you're using a deployed scheduler. 
 
-   ```bash
-   cd samples/durable-task-sdks/dotnet/FunctionChaining/Worker
-   dotnet run
-   ```
-
-1. In a separate terminal, run the Client (orchestration initiator):
-   > **Note:** Remember to set the environment variables again if you're using a deployed scheduler. 
-
-   ```bash
-   cd samples/durable-task-sdks/dotnet/FunctionChaining/Client
-   dotnet run
-   ```
+    ```bash
+    cd samples/durable-task-sdks/dotnet/FunctionChaining/Client
+    dotnet run
+    ```
 
 ### Deploying with Azure Developer CLI (AZD)
 

--- a/samples/durable-task-sdks/dotnet/FunctionChaining/README.md
+++ b/samples/durable-task-sdks/dotnet/FunctionChaining/README.md
@@ -24,7 +24,7 @@ This pattern is useful for:
 
 ## Configuring Durable Task Scheduler
 
-There are two ways to run this sample:
+There are two ways to run this sample locally: locally:
 
 ### Using the Emulator (Recommended)
 

--- a/samples/durable-task-sdks/dotnet/FunctionChaining/README.md
+++ b/samples/durable-task-sdks/dotnet/FunctionChaining/README.md
@@ -24,7 +24,7 @@ This pattern is useful for:
 
 ## Configuring Durable Task Scheduler
 
-There are two ways to run this sample locally: locally:
+There are two ways to run this sample locally:
 
 ### Using the Emulator (Recommended)
 

--- a/samples/durable-task-sdks/dotnet/HumanInteraction/README.md
+++ b/samples/durable-task-sdks/dotnet/HumanInteraction/README.md
@@ -19,7 +19,7 @@ This pattern is useful for:
 ## Prerequisites
 
 1. [.NET 8 SDK](https://dotnet.microsoft.com/download/dotnet/8.0) or later
-2. [Docker](https://www.docker.com/products/docker-desktop/) (for running the emulator)
+2. [Docker](https://www.docker.com/products/docker-desktop/) (for running the emulator) installed
 3. [Azure CLI](https://docs.microsoft.com/cli/azure/install-azure-cli) (if using a deployed Durable Task Scheduler)
 
 ## Configuring Durable Task Scheduler
@@ -37,7 +37,7 @@ The emulator simulates a scheduler and taskhub in a Docker container, making it 
 
 1. Run the Emulator:
     ```bash
-    docker run --name dtsemulator -d -p 8080:8080 -p 8082:8082 mcr.microsoft.com/dts/dts-emulator:latest
+    docker run -it -p 8080:8080 -p 8082:8082 mcr.microsoft.com/dts/dts-emulator:latest
     ```
 Wait a few seconds for the container to be ready.
 
@@ -45,25 +45,56 @@ Note: The example code automatically uses the default emulator settings (endpoin
 
 ### Using a Deployed Scheduler and Taskhub in Azure
 
-For production scenarios or when you're ready to deploy to Azure:
+Local development with a deployed scheduler:
 
-1. Create a Scheduler using the Azure CLI:
+1. Install the durable task scheduler CLI extension:
+
     ```bash
-    az durabletask scheduler create --resource-group <testrg> --name <testscheduler> --location <eastus> --ip-allowlist "[0.0.0.0/0]" --sku-capacity 1 --sku-name "Dedicated" --tags "{'myattribute':'myvalue'}"
+    az upgrade
+    az extension add --name durabletask --allow-preview true
     ```
 
-1. Create Your Taskhub:
+1. Create a resource group in a region where the Durable Task Scheduler is available:
+
     ```bash
-    az durabletask taskhub create --resource-group <testrg> --scheduler-name <testscheduler> --name <testtaskhub>
+    az provider show --namespace Microsoft.DurableTask --query "resourceTypes[?resourceType=='schedulers'].locations | [0]" --out table
     ```
 
-1. Assign your identity access to the task hub: 
     ```bash
-    assignee=$(az ad user show --id "someone@microsoft.com" --query "id" --output tsv)
+    az group create --name my-resource-group --location <location>
+    ```
 
-    scope="/subscriptions/<subscription-id>/resourceGroups/<resource-group>/providers/Microsoft.DurableTask/schedulers/<scheduler-name>/taskHubs/<taskhub-name>"
+1. Create a durable task scheduler resource:
 
-    az role assignment create --assignee "$assignee" --role "Durable Task Data Contributor" --scope "$scope"
+    ```bash
+    az durabletask scheduler create \
+        --resource-group my-resource-group \
+        --name my-scheduler \
+        --ip-allowlist '["0.0.0.0/0"]' \
+        --sku-name "Dedicated" \
+        --sku-capacity 1 \
+        --tags "{'myattribute':'myvalue'}"
+    ```
+
+1. Create a task hub within the scheduler resource:
+
+    ```bash
+    az durabletask taskhub create \
+        --resource-group my-resource-group \
+        --scheduler-name my-scheduler \
+        --name "my-taskhub"
+    ```
+
+1. Grant the current user permission to connect to the `my-taskhub` task hub:
+
+    ```bash
+    subscriptionId=$(az account show --query "id" -o tsv)
+    loggedInUser=$(az account show --query "user.name" -o tsv)
+
+    az role assignment create \
+        --assignee $loggedInUser \
+        --role "Durable Task Data Contributor" \
+        --scope "/subscriptions/$subscriptionId/resourceGroups/my-resource-group/providers/Microsoft.DurableTask/schedulers/my-scheduler/taskHubs/my-taskhub"
     ```
 
 ## Authentication
@@ -71,7 +102,7 @@ For production scenarios or when you're ready to deploy to Azure:
 The sample includes smart detection of the environment and configures authentication automatically:
 
 - For local development with the emulator (when endpoint is http://localhost:8080), no authentication is required.
-- For Azure deployments, DefaultAzureCredential is used, which tries multiple authentication methods:
+- For local development with a deployed scheduler, DefaultAzure authentication is used, which utilizes DefaultAzureCredential behind the scenes and tries multiple authentication methods:
   - Managed Identity
   - Environment variables (AZURE_CLIENT_ID, AZURE_TENANT_ID, AZURE_CLIENT_SECRET)
   - Azure CLI login
@@ -83,7 +114,7 @@ The connection string is constructed dynamically based on the environment:
 // For local emulator
 connectionString = $"Endpoint={schedulerEndpoint};TaskHub={taskHubName};Authentication=None";
 
-// For Azure
+// For Azure deployed emulator
 connectionString = $"Endpoint={schedulerEndpoint};TaskHub={taskHubName};Authentication=DefaultAzure";
 ```
 
@@ -91,18 +122,15 @@ connectionString = $"Endpoint={schedulerEndpoint};TaskHub={taskHubName};Authenti
 
 Once you have set up either the emulator or deployed scheduler, follow these steps to run the sample:
 
-1.  If you're using a deployed scheduler, you need set Environment Variables. Note the scheduler endpoint can be found in the Scheduler's overview tab on Azure Portal.
-
-    Bash:
+1.  If you're using a deployed scheduler, you need to set Environment Variables.
     ```bash
-    export TASKHUB=<taskhubname>
-    export ENDPOINT=<schedulerEndpoint>
-    ```
+    export ENDPOINT=$(az durabletask scheduler show \
+        --resource-group my-resource-group \
+        --name my-scheduler \
+        --query "properties.endpoint" \
+        --output tsv)
 
-    PowerShell:
-    ```powershell
-    $env:TASKHUB = "<taskhubname>"
-    $env:ENDPOINT = "<schedulerEndpoint>"
+    export TASKHUB="my-taskhub"
     ```
 
 1. Start the worker in a terminal:
@@ -119,7 +147,12 @@ Once you have set up either the emulator or deployed scheduler, follow these ste
     cd samples/durable-task-sdks/dotnet/HumanInteraction/Client
     dotnet run
     ```
+
     This will launch an interactive console client that creates an approval request and waits for your response.
+
+## Identity-based authentication
+
+Learn how to set up [identity-based authentication](https://learn.microsoft.com/azure/azure-functions/durable/durable-task-scheduler/durable-task-scheduler-identity?tabs=df&pivots=az-cli) when you deploy the app Azure.  
 
 ## Understanding the Code Structure
 

--- a/samples/durable-task-sdks/dotnet/HumanInteraction/README.md
+++ b/samples/durable-task-sdks/dotnet/HumanInteraction/README.md
@@ -30,17 +30,15 @@ There are two ways to run this sample:
 
 The emulator simulates a scheduler and taskhub in a Docker container, making it ideal for development and learning.
 
-1. Install Docker if it's not already installed.
+1. Pull the Docker Image for the Emulator:
+    ```bash
+    docker pull mcr.microsoft.com/dts/dts-emulator:latest
+    ```
 
-2. Pull the Docker Image for the Emulator:
-```bash
-docker pull mcr.microsoft.com/dts/dts-emulator:latest
-```
-
-3. Run the Emulator:
-```bash
-docker run --name dtsemulator -d -p 8080:8080 -p 8082:8082 mcr.microsoft.com/dts/dts-emulator:latest
-```
+1. Run the Emulator:
+    ```bash
+    docker run --name dtsemulator -d -p 8080:8080 -p 8082:8082 mcr.microsoft.com/dts/dts-emulator:latest
+    ```
 Wait a few seconds for the container to be ready.
 
 Note: The example code automatically uses the default emulator settings (endpoint: http://localhost:8080, taskhub: default). You don't need to set any environment variables.
@@ -50,30 +48,23 @@ Note: The example code automatically uses the default emulator settings (endpoin
 For production scenarios or when you're ready to deploy to Azure:
 
 1. Create a Scheduler using the Azure CLI:
-```bash
-az durabletask scheduler create --resource-group <testrg> --name <testscheduler> --location <eastus> --ip-allowlist "[0.0.0.0/0]" --sku-capacity 1 --sku-name "Dedicated" --tags "{'myattribute':'myvalue'}"
-```
+    ```bash
+    az durabletask scheduler create --resource-group <testrg> --name <testscheduler> --location <eastus> --ip-allowlist "[0.0.0.0/0]" --sku-capacity 1 --sku-name "Dedicated" --tags "{'myattribute':'myvalue'}"
+    ```
 
-2. Create Your Taskhub:
-```bash
-az durabletask taskhub create --resource-group <testrg> --scheduler-name <testscheduler> --name <testtaskhub>
-```
+1. Create Your Taskhub:
+    ```bash
+    az durabletask taskhub create --resource-group <testrg> --scheduler-name <testscheduler> --name <testtaskhub>
+    ```
 
-3. Retrieve the Endpoint for the Scheduler from the Azure portal.
+1. Assign your identity access to the task hub: 
+    ```bash
+    assignee=$(az ad user show --id "someone@microsoft.com" --query "id" --output tsv)
 
-4. Set the Environment Variables:
+    scope="/subscriptions/<subscription-id>/resourceGroups/<resource-group>/providers/Microsoft.DurableTask/schedulers/<scheduler-name>/taskHubs/<taskhub-name>"
 
-   Bash:
-   ```bash
-   export TASKHUB=<taskhubname>
-   export ENDPOINT=<taskhubEndpoint>
-   ```
-
-   PowerShell:
-   ```powershell
-   $env:TASKHUB = "<taskhubname>"
-   $env:ENDPOINT = "<taskhubEndpoint>"
-   ```
+    az role assignment create --assignee "$assignee" --role "Durable Task Data Contributor" --scope "$scope"
+    ```
 
 ## Authentication
 
@@ -90,29 +81,45 @@ The sample includes smart detection of the environment and configures authentica
 The connection string is constructed dynamically based on the environment:
 ```csharp
 // For local emulator
-connectionString = $"Endpoint={hostAddress};TaskHub={taskHubName};Authentication=None";
+connectionString = $"Endpoint={schedulerEndpoint};TaskHub={taskHubName};Authentication=None";
 
 // For Azure
-connectionString = $"Endpoint={hostAddress};TaskHub={taskHubName};Authentication=DefaultAzure";
+connectionString = $"Endpoint={schedulerEndpoint};TaskHub={taskHubName};Authentication=DefaultAzure";
 ```
 
 ## How to Run the Sample
 
 Once you have set up either the emulator or deployed scheduler, follow these steps to run the sample:
 
-1. Start the worker in a terminal:
-```bash
-cd samples\durable-task-sdks\dotnet\HumanInteraction\Worker
-dotnet run
-```
-You should see output indicating the worker has started and registered the orchestration and activities.
+1.  If you're using a deployed scheduler, you need set Environment Variables. Note the scheduler endpoint can be found in the Scheduler's overview tab on Azure Portal.
 
-2. In a new terminal, run the client:
-```bash
-cd samples\durable-task-sdks\dotnet\HumanInteraction\Client
-dotnet run
-```
-This will launch an interactive console client that creates an approval request and waits for your response.
+    Bash:
+    ```bash
+    export TASKHUB=<taskhubname>
+    export ENDPOINT=<schedulerEndpoint>
+    ```
+
+    PowerShell:
+    ```powershell
+    $env:TASKHUB = "<taskhubname>"
+    $env:ENDPOINT = "<schedulerEndpoint>"
+    ```
+
+1. Start the worker in a terminal:
+    ```bash
+    cd samples/durable-task-sdks/dotnet/HumanInteraction/Worker
+    dotnet run
+    ```
+    You should see output indicating the worker has started and registered the orchestration and activities.
+
+1. In a new terminal, run the client:
+    > **Note:** Remember to set the environment variables again if you're using a deployed scheduler. 
+
+    ```bash
+    cd samples/durable-task-sdks/dotnet/HumanInteraction/Client
+    dotnet run
+    ```
+    This will launch an interactive console client that creates an approval request and waits for your response.
 
 ## Understanding the Code Structure
 

--- a/samples/durable-task-sdks/dotnet/HumanInteraction/README.md
+++ b/samples/durable-task-sdks/dotnet/HumanInteraction/README.md
@@ -24,7 +24,7 @@ This pattern is useful for:
 
 ## Configuring Durable Task Scheduler
 
-There are two ways to run this sample:
+There are two ways to run this sample locally: locally:
 
 ### Using the Emulator (Recommended)
 

--- a/samples/durable-task-sdks/dotnet/HumanInteraction/README.md
+++ b/samples/durable-task-sdks/dotnet/HumanInteraction/README.md
@@ -24,7 +24,7 @@ This pattern is useful for:
 
 ## Configuring Durable Task Scheduler
 
-There are two ways to run this sample locally: locally:
+There are two ways to run this sample locally:
 
 ### Using the Emulator (Recommended)
 

--- a/samples/durable-task-sdks/dotnet/OrchestrationVersioning/README.md
+++ b/samples/durable-task-sdks/dotnet/OrchestrationVersioning/README.md
@@ -4,16 +4,38 @@ In addition to [Durable Functions](https://learn.microsoft.com/azure/azure-funct
 
 This directory includes a sample .NET console app that demonstrates how to utilize Orchestration Versioning with the Durable Task SDK for .NET.
 
-## Prerequisites
-
 - [.NET 8 SDK](https://dotnet.microsoft.com/download/dotnet/8.0)
 - [Azure CLI](https://docs.microsoft.com/cli/azure/install-azure-cli)
+- [Docker](https://www.docker.com/products/docker-desktop/) (for running the emulator) installed
 
-## Creating a durable task scheduler task hub
 
-Before you can run the app, you need to create a durable task scheduler task hub in Azure.
+## Configuring Durable Task Scheduler
 
-> **NOTE**: These are abbreviated instructions for simplicity. For a full set of instructions, see the Azure Durable Functions [QuickStart guide](../../../../quickstarts/HelloCities/README.md#create-a-durable-task-scheduler-namespace-and-task-hub).
+There are two ways to run this sample:
+
+### Using the Emulator (Recommended)
+
+The emulator simulates a scheduler and taskhub in a Docker container, making it ideal for development and learning.
+
+1. Pull the Docker Image for the Emulator:
+    ```bash
+    docker pull mcr.microsoft.com/dts/dts-emulator:latest
+    ```
+
+1. Run the Emulator:
+    ```bash
+    docker run -it -p 8080:8080 -p 8082:8082 mcr.microsoft.com/dts/dts-emulator:latest
+    ```
+    Wait a few seconds for the container to be ready.
+
+1. Set the scheduler connection string:
+    ```bash
+    export DURABLE_TASK_SCHEDULER_CONNECTION_STRING="Endpoint=http://localhost:8080;TaskHub=default;Authentication=None"
+    ```
+
+### Using a Deployed Scheduler and Taskhub in Azure
+
+Local development with a deployed scheduler:
 
 1. Install the durable task scheduler CLI extension:
 
@@ -22,26 +44,17 @@ Before you can run the app, you need to create a durable task scheduler task hub
     az extension add --name durabletask --allow-preview true
     ```
 
-1. Create a resource group:
+1. Create a resource group in a region where the Durable Task Scheduler is available:
 
     ```bash
-    az group create --name my-resource-group --location northcentralus
+    az provider show --namespace Microsoft.DurableTask --query "resourceTypes[?resourceType=='schedulers'].locations | [0]" --out table
+    ```
+
+    ```bash
+    az group create --name my-resource-group --location <location>
     ```
 
 1. Create a durable task scheduler resource:
-
-    **PowerShell**:
-
-    ```powershell
-    az durabletask scheduler create `
-        --resource-group my-resource-group `
-        --name my-scheduler `
-        --ip-allowlist '["0.0.0.0/0"]' `
-        --sku-name "Dedicated" `
-        --sku-capacity 1
-    ```
-
-    **Bash**:
 
     ```bash
     az durabletask scheduler create \
@@ -49,44 +62,20 @@ Before you can run the app, you need to create a durable task scheduler task hub
         --name my-scheduler \
         --ip-allowlist '["0.0.0.0/0"]' \
         --sku-name "Dedicated" \
-        --sku-capacity 1
+        --sku-capacity 1 \
+        --tags "{'myattribute':'myvalue'}"
     ```
 
 1. Create a task hub within the scheduler resource:
-
-    **PowerShell**:
-
-    ```powershell
-    az durabletask taskhub create `
-        --resource-group my-resource-group `
-        --scheduler-name my-scheduler `
-        --name "durable-task-dotnet"
-    ```
-
-    **Bash**:
 
     ```bash
     az durabletask taskhub create \
         --resource-group my-resource-group \
         --scheduler-name my-scheduler \
-        --name "durable-task-dotnet"
+        --name "my-taskhub"
     ```
 
-1. Grant the current user permission to connect to the `durable-task-dotnet` task hub:
-
-    **PowerShell**:
-
-    ```powershell
-    $subscriptionId = az account show --query "id" -o tsv
-    $loggedInUser = az account show --query "user.name" -o tsv
-
-    az role assignment create `
-        --assignee $loggedInUser `
-        --role "Durable Task Data Contributor" `
-        --scope "/subscriptions/$subscriptionId/resourceGroups/my-resource-group/providers/Microsoft.DurableTask/schedulers/my-scheduler/taskHubs/durable-task-dotnet"
-    ```
-
-    **Bash**:
+1. Grant the current user permission to connect to the `my-taskhub` task hub:
 
     ```bash
     subscriptionId=$(az account show --query "id" -o tsv)
@@ -95,26 +84,12 @@ Before you can run the app, you need to create a durable task scheduler task hub
     az role assignment create \
         --assignee $loggedInUser \
         --role "Durable Task Data Contributor" \
-        --scope "/subscriptions/$subscriptionId/resourceGroups/my-resource-group/providers/Microsoft.DurableTask/schedulers/my-scheduler/taskHubs/durable-task-dotnet"
+        --scope "/subscriptions/$subscriptionId/resourceGroups/my-resource-group/providers/Microsoft.DurableTask/schedulers/my-scheduler/taskHubs/my-taskhub"
     ```
 
     Note that it may take a minute for the role assignment to take effect.
 
 1. Generate a connection string for the scheduler and task hub resources and save it to the `DURABLE_TASK_SCHEDULER_CONNECTION_STRING` environment variable:
-
-    **PowerShell**:
-
-    ```powershell
-    $endpoint = az durabletask scheduler show `
-        --resource-group my-resource-group `
-        --name my-scheduler `
-        --query "properties.endpoint" `
-        --output tsv
-    $taskhub = "durable-task-dotnet"
-    $env:DURABLE_TASK_SCHEDULER_CONNECTION_STRING = "Endpoint=$endpoint;TaskHub=$taskhub;Authentication=DefaultAzure"
-    ```
-
-    **Bash**:
 
     ```bash
     endpoint=$(az durabletask scheduler show \
@@ -122,12 +97,12 @@ Before you can run the app, you need to create a durable task scheduler task hub
         --name my-scheduler \
         --query "properties.endpoint" \
         --output tsv)
-    taskhub="durable-task-dotnet"
+    taskhub="my-taskhub"
     export DURABLE_TASK_SCHEDULER_CONNECTION_STRING="Endpoint=$endpoint;TaskHub=$taskhub;Authentication=DefaultAzure"
     ```
 
     The `DURABLE_TASK_SCHEDULER_CONNECTION_STRING` environment variable is used by the sample app to connect to the durable task scheduler resources. The type of credential to use is specified by the `Authentication` segment. Supported values include `DefaultAzure`, `ManagedIdentity`, `WorkloadIdentity`, `Environment`, `AzureCLI`, and `AzurePowerShell`.
-
+    
 ## Orchestration Versioning
 
 A key issue in orchestration based workflows is handling different versions of orchestrations. Without any functionality built around versioning, the issue occurs when the number or order of tasks is changed in an orchestration. During the replay of events (for any inprogress orchestrations), the history will not match and a `NonDeterministicError` will be returned as the orchestration fails. The .NET portable SDK for Durable Task now offers several options for how to handle versioning in orchestrations.
@@ -261,7 +236,7 @@ Use the following PowerShell command from a new terminal window to get the dashb
 $dashboardUrl = az durabletask taskhub show `
     --resource-group "my-resource-group" `
     --scheduler-name "my-scheduler" `
-    --name "durable-task-dotnet" `
+    --name "my-taskhub" `
     --query "properties.dashboardUrl" `
     --output tsv
 $dashboardUrl
@@ -273,7 +248,7 @@ $dashboardUrl
 dashboardUrl=$(az durabletask taskhub show \
     --resource-group "my-resource-group" \
     --scheduler-name "my-scheduler" \
-    --name "durable-task-dotnet" \
+    --name "my-taskhub" \
     --query "properties.dashboardUrl" \
     --output tsv)
 echo $dashboardUrl
@@ -282,7 +257,7 @@ echo $dashboardUrl
 The URL should look something like the following:
 
 ```plaintext
-https://dashboard.durabletask.io/subscriptions/{subscriptionID}/schedulers/my-scheduler/taskhubs/durable-task-dotnet?endpoint=https%3a%2f%2fmy-scheduler-gvdmebc6dmdj.northcentralus.durabletask.io
+https://dashboard.durabletask.io/subscriptions/{subscriptionID}/schedulers/my-scheduler/taskhubs/my-taskhub?endpoint=https%3a%2f%2fmy-scheduler-gvdmebc6dmdj.northcentralus.durabletask.io
 ```
 
 Once logged in, you should see the orchestrations that were created by the sample app. Below is an example of what the dashboard might look like (note that some of the details will be different than the screenshot):

--- a/samples/durable-task-sdks/dotnet/OrchestrationVersioning/README.md
+++ b/samples/durable-task-sdks/dotnet/OrchestrationVersioning/README.md
@@ -60,7 +60,7 @@ Before you can run the app, you need to create a durable task scheduler task hub
     az durabletask taskhub create `
         --resource-group my-resource-group `
         --scheduler-name my-scheduler `
-        --name "portable-dotnet"
+        --name "durable-task-dotnet"
     ```
 
     **Bash**:
@@ -69,10 +69,10 @@ Before you can run the app, you need to create a durable task scheduler task hub
     az durabletask taskhub create \
         --resource-group my-resource-group \
         --scheduler-name my-scheduler \
-        --name "portable-dotnet"
+        --name "durable-task-dotnet"
     ```
 
-1. Grant the current user permission to connect to the `portable-dotnet` task hub:
+1. Grant the current user permission to connect to the `durable-task-dotnet` task hub:
 
     **PowerShell**:
 
@@ -83,7 +83,7 @@ Before you can run the app, you need to create a durable task scheduler task hub
     az role assignment create `
         --assignee $loggedInUser `
         --role "Durable Task Data Contributor" `
-        --scope "/subscriptions/$subscriptionId/resourceGroups/my-resource-group/providers/Microsoft.DurableTask/schedulers/my-scheduler/taskHubs/portable-dotnet"
+        --scope "/subscriptions/$subscriptionId/resourceGroups/my-resource-group/providers/Microsoft.DurableTask/schedulers/my-scheduler/taskHubs/durable-task-dotnet"
     ```
 
     **Bash**:
@@ -95,7 +95,7 @@ Before you can run the app, you need to create a durable task scheduler task hub
     az role assignment create \
         --assignee $loggedInUser \
         --role "Durable Task Data Contributor" \
-        --scope "/subscriptions/$subscriptionId/resourceGroups/my-resource-group/providers/Microsoft.DurableTask/schedulers/my-scheduler/taskHubs/portable-dotnet"
+        --scope "/subscriptions/$subscriptionId/resourceGroups/my-resource-group/providers/Microsoft.DurableTask/schedulers/my-scheduler/taskHubs/durable-task-dotnet"
     ```
 
     Note that it may take a minute for the role assignment to take effect.
@@ -110,7 +110,7 @@ Before you can run the app, you need to create a durable task scheduler task hub
         --name my-scheduler `
         --query "properties.endpoint" `
         --output tsv
-    $taskhub = "portable-dotnet"
+    $taskhub = "durable-task-dotnet"
     $env:DURABLE_TASK_SCHEDULER_CONNECTION_STRING = "Endpoint=$endpoint;TaskHub=$taskhub;Authentication=DefaultAzure"
     ```
 
@@ -122,7 +122,7 @@ Before you can run the app, you need to create a durable task scheduler task hub
         --name my-scheduler \
         --query "properties.endpoint" \
         --output tsv)
-    taskhub="portable-dotnet"
+    taskhub="durable-task-dotnet"
     export DURABLE_TASK_SCHEDULER_CONNECTION_STRING="Endpoint=$endpoint;TaskHub=$taskhub;Authentication=DefaultAzure"
     ```
 
@@ -261,7 +261,7 @@ Use the following PowerShell command from a new terminal window to get the dashb
 $dashboardUrl = az durabletask taskhub show `
     --resource-group "my-resource-group" `
     --scheduler-name "my-scheduler" `
-    --name "portable-dotnet" `
+    --name "durable-task-dotnet" `
     --query "properties.dashboardUrl" `
     --output tsv
 $dashboardUrl
@@ -273,7 +273,7 @@ $dashboardUrl
 dashboardUrl=$(az durabletask taskhub show \
     --resource-group "my-resource-group" \
     --scheduler-name "my-scheduler" \
-    --name "portable-dotnet" \
+    --name "durable-task-dotnet" \
     --query "properties.dashboardUrl" \
     --output tsv)
 echo $dashboardUrl
@@ -282,7 +282,7 @@ echo $dashboardUrl
 The URL should look something like the following:
 
 ```plaintext
-https://dashboard.durabletask.io/subscriptions/{subscriptionID}/schedulers/my-scheduler/taskhubs/portable-dotnet?endpoint=https%3a%2f%2fmy-scheduler-gvdmebc6dmdj.northcentralus.durabletask.io
+https://dashboard.durabletask.io/subscriptions/{subscriptionID}/schedulers/my-scheduler/taskhubs/durable-task-dotnet?endpoint=https%3a%2f%2fmy-scheduler-gvdmebc6dmdj.northcentralus.durabletask.io
 ```
 
 Once logged in, you should see the orchestrations that were created by the sample app. Below is an example of what the dashboard might look like (note that some of the details will be different than the screenshot):

--- a/samples/durable-task-sdks/dotnet/OrchestrationVersioning/README.md
+++ b/samples/durable-task-sdks/dotnet/OrchestrationVersioning/README.md
@@ -11,7 +11,7 @@ This directory includes a sample .NET console app that demonstrates how to utili
 
 ## Configuring Durable Task Scheduler
 
-There are two ways to run this sample locally: locally:
+There are two ways to run this sample locally:
 
 ### Using the Emulator (Recommended)
 

--- a/samples/durable-task-sdks/dotnet/OrchestrationVersioning/README.md
+++ b/samples/durable-task-sdks/dotnet/OrchestrationVersioning/README.md
@@ -11,7 +11,7 @@ This directory includes a sample .NET console app that demonstrates how to utili
 
 ## Configuring Durable Task Scheduler
 
-There are two ways to run this sample:
+There are two ways to run this sample locally: locally:
 
 ### Using the Emulator (Recommended)
 
@@ -102,7 +102,7 @@ Local development with a deployed scheduler:
     ```
 
     The `DURABLE_TASK_SCHEDULER_CONNECTION_STRING` environment variable is used by the sample app to connect to the durable task scheduler resources. The type of credential to use is specified by the `Authentication` segment. Supported values include `DefaultAzure`, `ManagedIdentity`, `WorkloadIdentity`, `Environment`, `AzureCLI`, and `AzurePowerShell`.
-    
+
 ## Orchestration Versioning
 
 A key issue in orchestration based workflows is handling different versions of orchestrations. Without any functionality built around versioning, the issue occurs when the number or order of tasks is changed in an orchestration. During the replay of events (for any inprogress orchestrations), the history will not match and a `NonDeterministicError` will be returned as the orchestration fails. The .NET portable SDK for Durable Task now offers several options for how to handle versioning in orchestrations.

--- a/samples/durable-task-sdks/dotnet/ScheduleWebApp/README.md
+++ b/samples/durable-task-sdks/dotnet/ScheduleWebApp/README.md
@@ -4,86 +4,131 @@ This sample demonstrates a web application that leverages the durable task sched
 
 ## Prerequisites
 
-- [.NET 8 SDK](https://dotnet.microsoft.com/download/dotnet/8.0)
-- [Azure CLI](https://docs.microsoft.com/cli/azure/install-azure-cli)
-- Azure subscription 
+1. [.NET 8 SDK](https://dotnet.microsoft.com/download/dotnet/8.0) or later
+2. [Docker](https://www.docker.com/products/docker-desktop/) (for running the emulator) installed
+3. [Azure CLI](https://docs.microsoft.com/cli/azure/install-azure-cli) (if using a deployed Durable Task Scheduler)
 
-## Setup
+## Configuring Durable Task Scheduler
+
+There are two ways to run this sample:
+
+### Using the Emulator (Recommended)
+
+The emulator simulates a scheduler and taskhub in a Docker container, making it ideal for development and learning.
+
+1. Pull the Docker Image for the Emulator:
+    ```bash
+    docker pull mcr.microsoft.com/dts/dts-emulator:latest
+    ```
+
+1. Run the Emulator:
+    ```bash
+    docker run -it -p 8080:8080 -p 8082:8082 mcr.microsoft.com/dts/dts-emulator:latest
+    ```
+Wait a few seconds for the container to be ready.
+
+Note: The example code automatically uses the default emulator settings (endpoint: http://localhost:8080, taskhub: default). You don't need to set any environment variables.
+
+### Using a Deployed Scheduler and Taskhub in Azure
+
+Local development with a deployed scheduler:
 
 1. Install the durable task scheduler CLI extension:
-   ```bash
-   az upgrade
-   az extension add --name durabletask --allow-preview true
-   ```
 
-2. Create and configure Azure resources:
-   ```bash
-   # Create resource group
-   az group create --name my-resource-group --location northcentralus
+    ```bash
+    az upgrade
+    az extension add --name durabletask --allow-preview true
+    ```
 
-   # Create scheduler
-   az durabletask scheduler create \
-       --resource-group my-resource-group \
-       --name my-scheduler \
-       --ip-allowlist '["0.0.0.0/0"]' \
-       --sku-name "Dedicated" \
-       --sku-capacity 1
+1. Create a resource group in a region where the Durable Task Scheduler is available:
 
-   # Create task hub
-   az durabletask taskhub create \
-       --resource-group my-resource-group \
-       --scheduler-name my-scheduler \
-       --name "schedule-webapp"
-   ```
+    ```bash
+    az provider show --namespace Microsoft.DurableTask --query "resourceTypes[?resourceType=='schedulers'].locations | [0]" --out table
+    ```
 
-3. Grant permissions to your account:
-   ```bash
-   subscriptionId=$(az account show --query "id" -o tsv)
-   loggedInUser=$(az account show --query "user.name" -o tsv)
+    ```bash
+    az group create --name my-resource-group --location <location>
+    ```
 
-   az role assignment create \
-       --assignee $loggedInUser \
-       --role "Durable Task Data Contributor" \
-       --scope "/subscriptions/$subscriptionId/resourceGroups/my-resource-group/providers/Microsoft.DurableTask/schedulers/my-scheduler/taskHubs/schedule-webapp"
-   ```
+1. Create a durable task scheduler resource:
 
-4. Configure the connection string:
+    ```bash
+    az durabletask scheduler create \
+        --resource-group my-resource-group \
+        --name my-scheduler \
+        --ip-allowlist '["0.0.0.0/0"]' \
+        --sku-name "Dedicated" \
+        --sku-capacity 1 \
+        --tags "{'myattribute':'myvalue'}"
+    ```
 
-   **PowerShell**:
-   ```powershell
-   $endpoint = az durabletask scheduler show `
-       --resource-group my-resource-group `
-       --name my-scheduler `
-       --query "properties.endpoint" `
-       --output tsv
-   $taskhub = "schedule-webapp"
-   $env:DURABLE_TASK_SCHEDULER_CONNECTION_STRING = "Endpoint=$endpoint;TaskHub=$taskhub;Authentication=DefaultAzure"
-   ```
+1. Create a task hub within the scheduler resource:
 
-   **Bash**:
-   ```bash
-   endpoint=$(az durabletask scheduler show \
-       --resource-group my-resource-group \
-       --name my-scheduler \
-       --query "properties.endpoint" \
-       --output tsv)
-   taskhub="schedule-webapp"
-   export DURABLE_TASK_SCHEDULER_CONNECTION_STRING="Endpoint=$endpoint;TaskHub=$taskhub;Authentication=DefaultAzure"
-   ```
+    ```bash
+    az durabletask taskhub create \
+        --resource-group my-resource-group \
+        --scheduler-name my-scheduler \
+        --name "my-taskhub"
+    ```
 
-## Running the Application
+1. Grant the current user permission to connect to the `my-taskhub` task hub:
 
-1. Navigate to the application directory:
-   ```bash
-   cd samples/durable-task-sdks/dotnet/ScheduleWebApp
-   ```
+    ```bash
+    subscriptionId=$(az account show --query "id" -o tsv)
+    loggedInUser=$(az account show --query "user.name" -o tsv)
 
-2. Run the application:
-   ```bash
-   dotnet run
-   ```
+    az role assignment create \
+        --assignee $loggedInUser \
+        --role "Durable Task Data Contributor" \
+        --scope "/subscriptions/$subscriptionId/resourceGroups/my-resource-group/providers/Microsoft.DurableTask/schedulers/my-scheduler/taskHubs/my-taskhub"
+    ```
 
-The application will start and listen on `http://localhost:5000` by default.
+## Authentication
+
+The sample includes smart detection of the environment and configures authentication automatically:
+
+- For local development with the emulator (when endpoint is http://localhost:8080), no authentication is required.
+- For local development with a deployed scheduler, DefaultAzure authentication is used, which utilizes DefaultAzureCredential behind the scenes and tries multiple authentication methods:
+  - Managed Identity
+  - Environment variables (AZURE_CLIENT_ID, AZURE_TENANT_ID, AZURE_CLIENT_SECRET)
+  - Azure CLI login
+  - Visual Studio login
+  - and more
+
+The connection string is constructed dynamically based on the environment:
+```csharp
+// For local emulator
+connectionString = $"Endpoint={schedulerEndpoint};TaskHub={taskHubName};Authentication=None";
+
+// For Azure deployed emulator
+connectionString = $"Endpoint={schedulerEndpoint};TaskHub={taskHubName};Authentication=DefaultAzure";
+```
+
+## How to Run the Sample
+
+Once you have set up either the emulator or deployed scheduler, follow these steps to run the sample:
+
+1.  If you're using a deployed scheduler, you need to set Environment Variables.
+    ```bash
+    export ENDPOINT=$(az durabletask scheduler show \
+        --resource-group my-resource-group \
+        --name my-scheduler \
+        --query "properties.endpoint" \
+        --output tsv)
+
+    export TASKHUB="my-taskhub"
+    ```
+
+1.  Run the application
+    ```bash
+    cd samples/durable-task-sdks/dotnet/ScheduleWebApp
+    dotnet run
+    ```
+    The application will start and listen on `http://localhost:5000` by default.
+
+## Identity-based authentication
+
+Learn how to set up [identity-based authentication](https://learn.microsoft.com/azure/azure-functions/durable/durable-task-scheduler/durable-task-scheduler-identity?tabs=df&pivots=az-cli) when you deploy the app Azure.  
 
 ## API Endpoints
 

--- a/samples/durable-task-sdks/dotnet/ScheduleWebApp/README.md
+++ b/samples/durable-task-sdks/dotnet/ScheduleWebApp/README.md
@@ -10,7 +10,7 @@ This sample demonstrates a web application that leverages the durable task sched
 
 ## Configuring Durable Task Scheduler
 
-There are two ways to run this sample locally: locally: 
+There are two ways to run this sample locally:
 
 ### Using the Emulator (Recommended)
 

--- a/samples/durable-task-sdks/dotnet/ScheduleWebApp/README.md
+++ b/samples/durable-task-sdks/dotnet/ScheduleWebApp/README.md
@@ -10,7 +10,7 @@ This sample demonstrates a web application that leverages the durable task sched
 
 ## Configuring Durable Task Scheduler
 
-There are two ways to run this sample:
+There are two ways to run this sample locally: locally: 
 
 ### Using the Emulator (Recommended)
 

--- a/samples/durable-task-sdks/java/function-chaining/README.md
+++ b/samples/durable-task-sdks/java/function-chaining/README.md
@@ -32,7 +32,7 @@ This pattern is useful for:
 
 ## Configuring Durable Task Scheduler
 
-There are two ways to run this sample:
+There are two ways to run this sample locally:
 
 ### Using the Emulator (Recommended)
 
@@ -90,7 +90,7 @@ For production scenarios or when you're ready to deploy to Azure:
 
 ## How to Run the Sample
 
-There are two ways to run this sample: locally or deployed to Azure.
+There are two ways to run this sample locally: locally or deployed to Azure.
 
 ### Running Locally
 

--- a/samples/durable-task-sdks/python/async-http-api/README.md
+++ b/samples/durable-task-sdks/python/async-http-api/README.md
@@ -52,30 +52,55 @@ Note: The example code automatically uses the default emulator settings (endpoin
 
 ### Using a Deployed Scheduler and Taskhub in Azure
 
-For production scenarios or when you're ready to deploy to Azure:
+Local development with a deployed scheduler:
 
-1. Find regions that support the Durable Task Scheduler: 
-  ```bash
-  az provider show --namespace Microsoft.DurableTask --query "resourceTypes[?resourceType=='schedulers'].locations | [0]" --out table
-  ```
+1. Install the durable task scheduler CLI extension:
 
-1. Create a Scheduler using the Azure CLI:
-  ```bash
-  az durabletask scheduler create --resource-group <resource-group> --name <scheduler-name> --location <location> --ip-allowlist "[0.0.0.0/0]" --sku-capacity 1 --sku-name "Dedicated" --tags "{'myattribute':'myvalue'}"
-  ```
-
-1. Create Your Taskhub:
-  ```bash
-  az durabletask taskhub create --resource-group <resource-group> --scheduler-name <scheduler-name> --name <taskhub-name>
-  ```
-
-1. Assign your identity access to the task hub: 
     ```bash
-    assignee=$(az ad user show --id "someone@microsoft.com" --query "id" --output tsv)
+    az upgrade
+    az extension add --name durabletask --allow-preview true
+    ```
 
-    scope="/subscriptions/<subscription-id>/resourceGroups/<resource-group>/providers/Microsoft.DurableTask/schedulers/<scheduler-name>/taskHubs/<taskhub-name>"
+1. Create a resource group in a region where the Durable Task Scheduler is available:
 
-    az role assignment create --assignee "$assignee" --role "Durable Task Data Contributor" --scope "$scope"
+    ```bash
+    az provider show --namespace Microsoft.DurableTask --query "resourceTypes[?resourceType=='schedulers'].locations | [0]" --out table
+    ```
+
+    ```bash
+    az group create --name my-resource-group --location <location>
+    ```
+1. Create a durable task scheduler resource:
+
+    ```bash
+    az durabletask scheduler create \
+        --resource-group my-resource-group \
+        --name my-scheduler \
+        --ip-allowlist '["0.0.0.0/0"]' \
+        --sku-name "Dedicated" \
+        --sku-capacity 1 \
+        --tags "{'myattribute':'myvalue'}"
+    ```
+
+1. Create a task hub within the scheduler resource:
+
+    ```bash
+    az durabletask taskhub create \
+        --resource-group my-resource-group \
+        --scheduler-name my-scheduler \
+        --name "my-taskhub"
+    ```
+
+1. Grant the current user permission to connect to the `my-taskhub` task hub:
+
+    ```bash
+    subscriptionId=$(az account show --query "id" -o tsv)
+    loggedInUser=$(az account show --query "user.name" -o tsv)
+
+    az role assignment create \
+        --assignee $loggedInUser \
+        --role "Durable Task Data Contributor" \
+        --scope "/subscriptions/$subscriptionId/resourceGroups/my-resource-group/providers/Microsoft.DurableTask/schedulers/my-scheduler/taskHubs/my-taskhub"
     ```
 
 ## How to Run the Sample
@@ -88,11 +113,16 @@ Once you have set up either the emulator or deployed scheduler, follow these ste
   source venv/bin/activate  # On Windows, use: venv\Scripts\activate
   ```
 
-1.  If you're using a deployed scheduler, you need set Environment Variables. Note the scheduler endpoint can be found in the Scheduler's overview tab on Azure Portal.
-   ```bash
-   export TASKHUB=<taskhubname>
-   export ENDPOINT=<schedulerEndpoint>
-   ```
+1.  If you're using a deployed scheduler, you need set Environment Variables:
+  ```bash
+  export ENDPOINT=$(az durabletask scheduler show \
+      --resource-group my-resource-group \
+      --name my-scheduler \
+      --query "properties.endpoint" \
+      --output tsv)
+
+  export TASKHUB="my-taskhub"
+  ```
 
 1. Install the required packages:
   ```bash
@@ -136,6 +166,10 @@ Once you have set up either the emulator or deployed scheduler, follow these ste
      ```powershell
      Invoke-RestMethod -Uri "http://localhost:8000/api/operations/{operation_id}"
      ```
+
+## Identity-based authentication
+
+Learn how to set up [identity-based authentication](https://learn.microsoft.com/azure/azure-functions/durable/durable-task-scheduler/durable-task-scheduler-identity?tabs=df&pivots=az-cli) when you deploy the app Azure.  
 
 ## Understanding the Output
 

--- a/samples/durable-task-sdks/python/async-http-api/README.md
+++ b/samples/durable-task-sdks/python/async-http-api/README.md
@@ -25,7 +25,7 @@ This pattern is useful for:
 ## Prerequisites
 
 1. [Python 3.9+](https://www.python.org/downloads/)
-2. [Docker](https://www.docker.com/products/docker-desktop/) (for running the emulator)
+2. [Docker](https://www.docker.com/products/docker-desktop/) (for running the emulator) installed
 3. [Azure CLI](https://docs.microsoft.com/cli/azure/install-azure-cli) (if using a deployed Durable Task Scheduler)
 4. [FastAPI](https://fastapi.tiangolo.com/) and [Uvicorn](https://www.uvicorn.org/) (installed via requirements.txt)
 

--- a/samples/durable-task-sdks/python/async-http-api/README.md
+++ b/samples/durable-task-sdks/python/async-http-api/README.md
@@ -31,7 +31,7 @@ This pattern is useful for:
 
 ## Configuring Durable Task Scheduler
 
-There are two ways to run this sample:
+There are two ways to run this sample locally:
 
 ### Using the Emulator (Recommended)
 

--- a/samples/durable-task-sdks/python/async-http-api/README.md
+++ b/samples/durable-task-sdks/python/async-http-api/README.md
@@ -37,17 +37,15 @@ There are two ways to run this sample:
 
 The emulator simulates a scheduler and taskhub in a Docker container, making it ideal for development and learning.
 
-1. Install Docker if it's not already installed.
+1. Pull the Docker Image for the Emulator:
+  ```bash
+  docker pull mcr.microsoft.com/dts/dts-emulator:latest
+  ```
 
-2. Pull the Docker Image for the Emulator:
-```bash
-docker pull mcr.microsoft.com/dts/dts-emulator:latest
-```
-
-3. Run the Emulator:
-```bash
-docker run --name dtsemulator -d -p 8080:8080 -p 8082:8082 mcr.microsoft.com/dts/dts-emulator:latest
-```
+1. Run the Emulator:
+  ```bash
+  docker run --name dtsemulator -d -p 8080:8080 -p 8082:8082 mcr.microsoft.com/dts/dts-emulator:latest
+  ```
 Wait a few seconds for the container to be ready.
 
 Note: The example code automatically uses the default emulator settings (endpoint: http://localhost:8080, taskhub: default). You don't need to set any environment variables.
@@ -56,60 +54,66 @@ Note: The example code automatically uses the default emulator settings (endpoin
 
 For production scenarios or when you're ready to deploy to Azure:
 
+1. Find regions that support the Durable Task Scheduler: 
+  ```bash
+  az provider show --namespace Microsoft.DurableTask --query "resourceTypes[?resourceType=='schedulers'].locations | [0]" --out table
+  ```
+
 1. Create a Scheduler using the Azure CLI:
-```bash
-az durabletask scheduler create --resource-group <testrg> --name <testscheduler> --location <eastus> --ip-allowlist "[0.0.0.0/0]" --sku-capacity 1 --sku-name "Dedicated" --tags "{'myattribute':'myvalue'}"
-```
+  ```bash
+  az durabletask scheduler create --resource-group <resource-group> --name <scheduler-name> --location <location> --ip-allowlist "[0.0.0.0/0]" --sku-capacity 1 --sku-name "Dedicated" --tags "{'myattribute':'myvalue'}"
+  ```
 
-2. Create Your Taskhub:
-```bash
-az durabletask taskhub create --resource-group <testrg> --scheduler-name <testscheduler> --name <testtaskhub>
-```
+1. Create Your Taskhub:
+  ```bash
+  az durabletask taskhub create --resource-group <resource-group> --scheduler-name <scheduler-name> --name <taskhub-name>
+  ```
 
-3. Retrieve the Endpoint for the Scheduler from the Azure portal.
+1. Assign your identity access to the task hub: 
+    ```bash
+    assignee=$(az ad user show --id "someone@microsoft.com" --query "id" --output tsv)
 
-4. Set the Environment Variables:
+    scope="/subscriptions/<subscription-id>/resourceGroups/<resource-group>/providers/Microsoft.DurableTask/schedulers/<scheduler-name>/taskHubs/<taskhub-name>"
 
-   Bash:
-   ```bash
-   export TASKHUB=<taskhubname>
-   export ENDPOINT=<taskhubEndpoint>
-   ```
-
-   PowerShell:
-   ```powershell
-   $env:TASKHUB = "<taskhubname>"
-   $env:ENDPOINT = "<taskhubEndpoint>"
-   ```
+    az role assignment create --assignee "$assignee" --role "Durable Task Data Contributor" --scope "$scope"
+    ```
 
 ## How to Run the Sample
 
 Once you have set up either the emulator or deployed scheduler, follow these steps to run the sample:
 
 1. First, activate your Python virtual environment (if you're using one):
-```bash
-python -m venv venv
-source venv/bin/activate  # On Windows, use: venv\Scripts\activate
-```
+  ```bash
+  python -m venv venv
+  source venv/bin/activate  # On Windows, use: venv\Scripts\activate
+  ```
 
-2. Install the required packages:
-```bash
-pip install -r requirements.txt
-```
+1.  If you're using a deployed scheduler, you need set Environment Variables. Note the scheduler endpoint can be found in the Scheduler's overview tab on Azure Portal.
+   ```bash
+   export TASKHUB=<taskhubname>
+   export ENDPOINT=<schedulerEndpoint>
+   ```
 
-3. Start the worker in a terminal:
-```bash
-python worker.py
-```
-You should see output indicating the worker has started and registered the orchestration and activities.
+1. Install the required packages:
+  ```bash
+  pip install -r requirements.txt
+  ```
 
-4. In a new terminal (with the virtual environment activated if applicable), run the client (which is a FastAPI server):
-```bash
-python client.py
-```
-This will start a FastAPI server on port 8000.
+1. Start the worker in a terminal:
+  ```bash
+  python worker.py
+  ```
+  You should see output indicating the worker has started and registered the orchestration and activities.
 
-5. Interact with the API using a browser, curl, or PowerShell:
+1. In a new terminal (with the virtual environment activated if applicable), run the client (which is a FastAPI server):
+  > **Note:** Remember to set the environment variables again if you're using a deployed scheduler. 
+
+  ```bash
+  python client.py
+  ```
+  This will start a FastAPI server on port 8000.
+
+1. Interact with the API using a browser, curl, or PowerShell:
    
    **Using curl:**
    - To start a new operation:

--- a/samples/durable-task-sdks/python/eternal-orchestrations/README.md
+++ b/samples/durable-task-sdks/python/eternal-orchestrations/README.md
@@ -27,44 +27,69 @@ There are two ways to run this sample:
 The emulator simulates a scheduler and taskhub in a Docker container, making it ideal for development and learning.
 
 1. Pull the Docker Image for the Emulator:
-   ```bash
-   docker pull mcr.microsoft.com/dts/dts-emulator:latest
-   ```
+  ```bash
+  docker pull mcr.microsoft.com/dts/dts-emulator:latest
+  ```
 
 1. Run the Emulator:
-   ```bash
-   docker run --name dtsemulator -d -p 8080:8080 -p 8082:8082 mcr.microsoft.com/dts/dts-emulator:latest
-   ```
+  ```bash
+  docker run --name dtsemulator -d -p 8080:8080 -p 8082:8082 mcr.microsoft.com/dts/dts-emulator:latest
+  ```
 Wait a few seconds for the container to be ready.
 
 Note: The example code automatically uses the default emulator settings (endpoint: http://localhost:8080, taskhub: default). You don't need to set any environment variables.
 
 ### Using a Deployed Scheduler and Taskhub in Azure
 
-For production scenarios or when you're ready to deploy to Azure:
+Local development with a deployed scheduler:
 
-1. Find regions that support the Durable Task Scheduler: 
-  ```bash
-  az provider show --namespace Microsoft.DurableTask --query "resourceTypes[?resourceType=='schedulers'].locations | [0]" --out table
-  ```
+1. Install the durable task scheduler CLI extension:
 
-1. Create a Scheduler using the Azure CLI:
-  ```bash
-  az durabletask scheduler create --resource-group <resource-group> --name <scheduler-name> --location <location> --ip-allowlist "[0.0.0.0/0]" --sku-capacity 1 --sku-name "Dedicated" --tags "{'myattribute':'myvalue'}"
-  ```
-
-1. Create Your Taskhub:
-  ```bash
-  az durabletask taskhub create --resource-group <resource-group> --scheduler-name <scheduler-name> --name <taskhub-name>
-  ```
-
-1. Assign your identity access to the task hub: 
     ```bash
-    assignee=$(az ad user show --id "someone@microsoft.com" --query "id" --output tsv)
+    az upgrade
+    az extension add --name durabletask --allow-preview true
+    ```
 
-    scope="/subscriptions/<subscription-id>/resourceGroups/<resource-group>/providers/Microsoft.DurableTask/schedulers/<scheduler-name>/taskHubs/<taskhub-name>"
+1. Create a resource group in a region where the Durable Task Scheduler is available:
 
-    az role assignment create --assignee "$assignee" --role "Durable Task Data Contributor" --scope "$scope"
+    ```bash
+    az provider show --namespace Microsoft.DurableTask --query "resourceTypes[?resourceType=='schedulers'].locations | [0]" --out table
+    ```
+
+    ```bash
+    az group create --name my-resource-group --location <location>
+    ```
+1. Create a durable task scheduler resource:
+
+    ```bash
+    az durabletask scheduler create \
+        --resource-group my-resource-group \
+        --name my-scheduler \
+        --ip-allowlist '["0.0.0.0/0"]' \
+        --sku-name "Dedicated" \
+        --sku-capacity 1 \
+        --tags "{'myattribute':'myvalue'}"
+    ```
+
+1. Create a task hub within the scheduler resource:
+
+    ```bash
+    az durabletask taskhub create \
+        --resource-group my-resource-group \
+        --scheduler-name my-scheduler \
+        --name "my-taskhub"
+    ```
+
+1. Grant the current user permission to connect to the `my-taskhub` task hub:
+
+    ```bash
+    subscriptionId=$(az account show --query "id" -o tsv)
+    loggedInUser=$(az account show --query "user.name" -o tsv)
+
+    az role assignment create \
+        --assignee $loggedInUser \
+        --role "Durable Task Data Contributor" \
+        --scope "/subscriptions/$subscriptionId/resourceGroups/my-resource-group/providers/Microsoft.DurableTask/schedulers/my-scheduler/taskHubs/my-taskhub"
     ```
 
 ## How to Run the Sample
@@ -72,21 +97,26 @@ For production scenarios or when you're ready to deploy to Azure:
 Once you have set up either the emulator or deployed scheduler, follow these steps to run the sample:
 
 1. First, activate your Python virtual environment (if you're using one):
-   ```bash
-   python -m venv venv
-   source venv/bin/activate  # On Windows, use: venv\Scripts\activate
-   ```
+  ```bash
+  python -m venv venv
+  source venv/bin/activate  # On Windows, use: venv\Scripts\activate
+  ```
 
-1.  If you're using a deployed scheduler, you need set Environment Variables. Note the scheduler endpoint can be found in the Scheduler's overview tab on Azure Portal.
-   ```bash
-   export TASKHUB=<taskhubname>
-   export ENDPOINT=<schedulerEndpoint>
-   ```
+1.  If you're using a deployed scheduler, you need set Environment Variables:
+  ```bash
+  export ENDPOINT=$(az durabletask scheduler show \
+      --resource-group my-resource-group \
+      --name my-scheduler \
+      --query "properties.endpoint" \
+      --output tsv)
+
+  export TASKHUB="my-taskhub"
+  ```
 
 1. Install the required packages:
-   ```bash
-   pip install -r requirements.txt
-   ```
+  ```bash
+  pip install -r requirements.txt
+  ```
 
 1. Start the worker in a terminal:
    ```bash
@@ -100,6 +130,10 @@ Once you have set up either the emulator or deployed scheduler, follow these ste
    ```bash
    python client.py
    ```
+
+## Identity-based authentication
+
+Learn how to set up [identity-based authentication](https://learn.microsoft.com/azure/azure-functions/durable/durable-task-scheduler/durable-task-scheduler-identity?tabs=df&pivots=az-cli) when you deploy the app Azure.  
 
 ## Understanding the Output
 

--- a/samples/durable-task-sdks/python/eternal-orchestrations/README.md
+++ b/samples/durable-task-sdks/python/eternal-orchestrations/README.md
@@ -15,7 +15,7 @@ Eternal orchestrations are useful for recurring tasks, monitoring processes, or 
 ## Prerequisites
 
 1. [Python 3.9+](https://www.python.org/downloads/)
-2. [Docker](https://www.docker.com/products/docker-desktop/) (for running the emulator)
+2. [Docker](https://www.docker.com/products/docker-desktop/) (for running the emulator) installed
 3. [Azure CLI](https://docs.microsoft.com/cli/azure/install-azure-cli) (if using a deployed Durable Task Scheduler)
 
 ## Configuring Durable Task Scheduler

--- a/samples/durable-task-sdks/python/eternal-orchestrations/README.md
+++ b/samples/durable-task-sdks/python/eternal-orchestrations/README.md
@@ -20,7 +20,7 @@ Eternal orchestrations are useful for recurring tasks, monitoring processes, or 
 
 ## Configuring Durable Task Scheduler
 
-There are two ways to run this sample:
+There are two ways to run this sample locally:
 
 ### Using the Emulator (Recommended)
 

--- a/samples/durable-task-sdks/python/eternal-orchestrations/README.md
+++ b/samples/durable-task-sdks/python/eternal-orchestrations/README.md
@@ -26,17 +26,15 @@ There are two ways to run this sample:
 
 The emulator simulates a scheduler and taskhub in a Docker container, making it ideal for development and learning.
 
-1. Install Docker if it's not already installed.
+1. Pull the Docker Image for the Emulator:
+   ```bash
+   docker pull mcr.microsoft.com/dts/dts-emulator:latest
+   ```
 
-2. Pull the Docker Image for the Emulator:
-```bash
-docker pull mcr.microsoft.com/dts/dts-emulator:latest
-```
-
-3. Run the Emulator:
-```bash
-docker run --name dtsemulator -d -p 8080:8080 -p 8082:8082 mcr.microsoft.com/dts/dts-emulator:latest
-```
+1. Run the Emulator:
+   ```bash
+   docker run --name dtsemulator -d -p 8080:8080 -p 8082:8082 mcr.microsoft.com/dts/dts-emulator:latest
+   ```
 Wait a few seconds for the container to be ready.
 
 Note: The example code automatically uses the default emulator settings (endpoint: http://localhost:8080, taskhub: default). You don't need to set any environment variables.
@@ -45,57 +43,63 @@ Note: The example code automatically uses the default emulator settings (endpoin
 
 For production scenarios or when you're ready to deploy to Azure:
 
+1. Find regions that support the Durable Task Scheduler: 
+  ```bash
+  az provider show --namespace Microsoft.DurableTask --query "resourceTypes[?resourceType=='schedulers'].locations | [0]" --out table
+  ```
+
 1. Create a Scheduler using the Azure CLI:
-```bash
-az durabletask scheduler create --resource-group <testrg> --name <testscheduler> --location <eastus> --ip-allowlist "[0.0.0.0/0]" --sku-capacity 1 --sku-name "Dedicated" --tags "{'myattribute':'myvalue'}"
-```
+  ```bash
+  az durabletask scheduler create --resource-group <resource-group> --name <scheduler-name> --location <location> --ip-allowlist "[0.0.0.0/0]" --sku-capacity 1 --sku-name "Dedicated" --tags "{'myattribute':'myvalue'}"
+  ```
 
-2. Create Your Taskhub:
-```bash
-az durabletask taskhub create --resource-group <testrg> --scheduler-name <testscheduler> --name <testtaskhub>
-```
+1. Create Your Taskhub:
+  ```bash
+  az durabletask taskhub create --resource-group <resource-group> --scheduler-name <scheduler-name> --name <taskhub-name>
+  ```
 
-3. Retrieve the Endpoint for the Scheduler from the Azure portal.
+1. Assign your identity access to the task hub: 
+    ```bash
+    assignee=$(az ad user show --id "someone@microsoft.com" --query "id" --output tsv)
 
-4. Set the Environment Variables:
+    scope="/subscriptions/<subscription-id>/resourceGroups/<resource-group>/providers/Microsoft.DurableTask/schedulers/<scheduler-name>/taskHubs/<taskhub-name>"
 
-   Bash:
-   ```bash
-   export TASKHUB=<taskhubname>
-   export ENDPOINT=<taskhubEndpoint>
-   ```
-
-   PowerShell:
-   ```powershell
-   $env:TASKHUB = "<taskhubname>"
-   $env:ENDPOINT = "<taskhubEndpoint>"
-   ```
+    az role assignment create --assignee "$assignee" --role "Durable Task Data Contributor" --scope "$scope"
+    ```
 
 ## How to Run the Sample
 
 Once you have set up either the emulator or deployed scheduler, follow these steps to run the sample:
 
 1. First, activate your Python virtual environment (if you're using one):
-```bash
-python -m venv venv
-source venv/bin/activate  # On Windows, use: venv\Scripts\activate
-```
+   ```bash
+   python -m venv venv
+   source venv/bin/activate  # On Windows, use: venv\Scripts\activate
+   ```
 
-2. Install the required packages:
-```bash
-pip install -r requirements.txt
-```
+1.  If you're using a deployed scheduler, you need set Environment Variables. Note the scheduler endpoint can be found in the Scheduler's overview tab on Azure Portal.
+   ```bash
+   export TASKHUB=<taskhubname>
+   export ENDPOINT=<schedulerEndpoint>
+   ```
 
-3. Start the worker in a terminal:
-```bash
-python worker.py
-```
-You should see output indicating the worker has started and registered the orchestration and activities.
+1. Install the required packages:
+   ```bash
+   pip install -r requirements.txt
+   ```
 
-4. In a new terminal (with the virtual environment activated if applicable), run the client:
-```bash
-python client.py
-```
+1. Start the worker in a terminal:
+   ```bash
+   python worker.py
+   ```
+   You should see output indicating the worker has started and registered the orchestration and activities.
+
+1. In a new terminal (with the virtual environment activated if applicable), run the client:
+  > **Note:** Remember to set the environment variables again if you're using a deployed scheduler. 
+
+   ```bash
+   python client.py
+   ```
 
 ## Understanding the Output
 

--- a/samples/durable-task-sdks/python/fan-out-fan-in/README.md
+++ b/samples/durable-task-sdks/python/fan-out-fan-in/README.md
@@ -25,7 +25,7 @@ This pattern is useful for:
 
 ## Configuring Durable Task Scheduler
 
-There are two ways to run this sample:
+There are two ways to run this sample locally:
 
 ### Using the Emulator (Recommended)
 

--- a/samples/durable-task-sdks/python/fan-out-fan-in/README.md
+++ b/samples/durable-task-sdks/python/fan-out-fan-in/README.md
@@ -20,7 +20,7 @@ This pattern is useful for:
 ## Prerequisites
 
 1. [Python 3.9+](https://www.python.org/downloads/)
-2. [Docker](https://www.docker.com/products/docker-desktop/) (for running the emulator)
+2. [Docker](https://www.docker.com/products/docker-desktop/) (for running the emulator) installed
 3. [Azure CLI](https://docs.microsoft.com/cli/azure/install-azure-cli) (if using a deployed Durable Task Scheduler)
 
 ## Configuring Durable Task Scheduler

--- a/samples/durable-task-sdks/python/fan-out-fan-in/README.md
+++ b/samples/durable-task-sdks/python/fan-out-fan-in/README.md
@@ -31,17 +31,15 @@ There are two ways to run this sample:
 
 The emulator simulates a scheduler and taskhub in a Docker container, making it ideal for development and learning.
 
-1. Install Docker if it's not already installed.
+1. Pull the Docker Image for the Emulator:
+   ```bash
+   docker pull mcr.microsoft.com/dts/dts-emulator:latest
+   ```
 
-2. Pull the Docker Image for the Emulator:
-```bash
-docker pull mcr.microsoft.com/dts/dts-emulator:latest
-```
-
-3. Run the Emulator:
-```bash
-docker run --name dtsemulator -d -p 8080:8080 -p 8082:8082 mcr.microsoft.com/dts/dts-emulator:latest
-```
+1. Run the Emulator:
+   ```bash
+   docker run --name dtsemulator -d -p 8080:8080 -p 8082:8082 mcr.microsoft.com/dts/dts-emulator:latest
+   ```
 Wait a few seconds for the container to be ready.
 
 Note: The example code automatically uses the default emulator settings (endpoint: http://localhost:8080, taskhub: default). You don't need to set any environment variables.
@@ -50,58 +48,64 @@ Note: The example code automatically uses the default emulator settings (endpoin
 
 For production scenarios or when you're ready to deploy to Azure:
 
+1. Find regions that support the Durable Task Scheduler: 
+  ```bash
+  az provider show --namespace Microsoft.DurableTask --query "resourceTypes[?resourceType=='schedulers'].locations | [0]" --out table
+  ```
+
 1. Create a Scheduler using the Azure CLI:
-```bash
-az durabletask scheduler create --resource-group <testrg> --name <testscheduler> --location <eastus> --ip-allowlist "[0.0.0.0/0]" --sku-capacity 1 --sku-name "Dedicated" --tags "{'myattribute':'myvalue'}"
-```
+  ```bash
+  az durabletask scheduler create --resource-group <resource-group> --name <scheduler-name> --location <location> --ip-allowlist "[0.0.0.0/0]" --sku-capacity 1 --sku-name "Dedicated" --tags "{'myattribute':'myvalue'}"
+  ```
 
-2. Create Your Taskhub:
-```bash
-az durabletask taskhub create --resource-group <testrg> --scheduler-name <testscheduler> --name <testtaskhub>
-```
+1. Create Your Taskhub:
+  ```bash
+  az durabletask taskhub create --resource-group <resource-group> --scheduler-name <scheduler-name> --name <taskhub-name>
+  ```
 
-3. Retrieve the Endpoint for the Scheduler from the Azure portal.
+1. Assign your identity access to the task hub: 
+    ```bash
+    assignee=$(az ad user show --id "someone@microsoft.com" --query "id" --output tsv)
 
-4. Set the Environment Variables:
+    scope="/subscriptions/<subscription-id>/resourceGroups/<resource-group>/providers/Microsoft.DurableTask/schedulers/<scheduler-name>/taskHubs/<taskhub-name>"
 
-   Bash:
-   ```bash
-   export TASKHUB=<taskhubname>
-   export ENDPOINT=<taskhubEndpoint>
-   ```
-
-   PowerShell:
-   ```powershell
-   $env:TASKHUB = "<taskhubname>"
-   $env:ENDPOINT = "<taskhubEndpoint>"
-   ```
+    az role assignment create --assignee "$assignee" --role "Durable Task Data Contributor" --scope "$scope"
+    ```
 
 ## How to Run the Sample
 
 Once you have set up either the emulator or deployed scheduler, follow these steps to run the sample:
 
 1. First, activate your Python virtual environment (if you're using one):
-```bash
-python -m venv venv
-source venv/bin/activate  # On Windows, use: venv\Scripts\activate
-```
+   ```bash
+   python -m venv venv
+   source venv/bin/activate  # On Windows, use: venv\Scripts\activate
+   ```
 
-2. Install the required packages:
-```bash
-pip install -r requirements.txt
-```
+1.  If you're using a deployed scheduler, you need set Environment Variables. Note the scheduler endpoint can be found in the Scheduler's overview tab on Azure Portal.
+   ```bash
+   export TASKHUB=<taskhubname>
+   export ENDPOINT=<schedulerEndpoint>
+   ```
 
-3. Start the worker in a terminal:
-```bash
-python worker.py
-```
-You should see output indicating the worker has started and registered the orchestration and activities.
+1. Install the required packages:
+   ```bash
+   pip install -r requirements.txt
+   ```
 
-4. In a new terminal (with the virtual environment activated if applicable), run the client:
-```bash
-python client.py [number_of_items]
-```
-You can optionally provide the number of work items as an argument. If not provided, 10 items will be used by default.
+1. Start the worker in a terminal:
+   ```bash
+   python worker.py
+   ```
+   You should see output indicating the worker has started and registered the orchestration and activities.
+
+1. In a new terminal (with the virtual environment activated if applicable), run the client:
+  > **Note:** Remember to set the environment variables again if you're using a deployed scheduler. 
+
+   ```bash
+   python client.py [number_of_items]
+   ```
+   You can optionally provide the number of work items as an argument. If not provided, 10 items will be used by default.
 
 ## Understanding the Output
 

--- a/samples/durable-task-sdks/python/fan-out-fan-in/README.md
+++ b/samples/durable-task-sdks/python/fan-out-fan-in/README.md
@@ -32,44 +32,69 @@ There are two ways to run this sample:
 The emulator simulates a scheduler and taskhub in a Docker container, making it ideal for development and learning.
 
 1. Pull the Docker Image for the Emulator:
-   ```bash
-   docker pull mcr.microsoft.com/dts/dts-emulator:latest
-   ```
+  ```bash
+  docker pull mcr.microsoft.com/dts/dts-emulator:latest
+  ```
 
 1. Run the Emulator:
-   ```bash
-   docker run --name dtsemulator -d -p 8080:8080 -p 8082:8082 mcr.microsoft.com/dts/dts-emulator:latest
-   ```
+  ```bash
+  docker run --name dtsemulator -d -p 8080:8080 -p 8082:8082 mcr.microsoft.com/dts/dts-emulator:latest
+  ```
 Wait a few seconds for the container to be ready.
 
 Note: The example code automatically uses the default emulator settings (endpoint: http://localhost:8080, taskhub: default). You don't need to set any environment variables.
 
 ### Using a Deployed Scheduler and Taskhub in Azure
 
-For production scenarios or when you're ready to deploy to Azure:
+Local development with a deployed scheduler:
 
-1. Find regions that support the Durable Task Scheduler: 
-  ```bash
-  az provider show --namespace Microsoft.DurableTask --query "resourceTypes[?resourceType=='schedulers'].locations | [0]" --out table
-  ```
+1. Install the durable task scheduler CLI extension:
 
-1. Create a Scheduler using the Azure CLI:
-  ```bash
-  az durabletask scheduler create --resource-group <resource-group> --name <scheduler-name> --location <location> --ip-allowlist "[0.0.0.0/0]" --sku-capacity 1 --sku-name "Dedicated" --tags "{'myattribute':'myvalue'}"
-  ```
-
-1. Create Your Taskhub:
-  ```bash
-  az durabletask taskhub create --resource-group <resource-group> --scheduler-name <scheduler-name> --name <taskhub-name>
-  ```
-
-1. Assign your identity access to the task hub: 
     ```bash
-    assignee=$(az ad user show --id "someone@microsoft.com" --query "id" --output tsv)
+    az upgrade
+    az extension add --name durabletask --allow-preview true
+    ```
 
-    scope="/subscriptions/<subscription-id>/resourceGroups/<resource-group>/providers/Microsoft.DurableTask/schedulers/<scheduler-name>/taskHubs/<taskhub-name>"
+1. Create a resource group in a region where the Durable Task Scheduler is available:
 
-    az role assignment create --assignee "$assignee" --role "Durable Task Data Contributor" --scope "$scope"
+    ```bash
+    az provider show --namespace Microsoft.DurableTask --query "resourceTypes[?resourceType=='schedulers'].locations | [0]" --out table
+    ```
+
+    ```bash
+    az group create --name my-resource-group --location <location>
+    ```
+1. Create a durable task scheduler resource:
+
+    ```bash
+    az durabletask scheduler create \
+        --resource-group my-resource-group \
+        --name my-scheduler \
+        --ip-allowlist '["0.0.0.0/0"]' \
+        --sku-name "Dedicated" \
+        --sku-capacity 1 \
+        --tags "{'myattribute':'myvalue'}"
+    ```
+
+1. Create a task hub within the scheduler resource:
+
+    ```bash
+    az durabletask taskhub create \
+        --resource-group my-resource-group \
+        --scheduler-name my-scheduler \
+        --name "my-taskhub"
+    ```
+
+1. Grant the current user permission to connect to the `my-taskhub` task hub:
+
+    ```bash
+    subscriptionId=$(az account show --query "id" -o tsv)
+    loggedInUser=$(az account show --query "user.name" -o tsv)
+
+    az role assignment create \
+        --assignee $loggedInUser \
+        --role "Durable Task Data Contributor" \
+        --scope "/subscriptions/$subscriptionId/resourceGroups/my-resource-group/providers/Microsoft.DurableTask/schedulers/my-scheduler/taskHubs/my-taskhub"
     ```
 
 ## How to Run the Sample
@@ -77,16 +102,21 @@ For production scenarios or when you're ready to deploy to Azure:
 Once you have set up either the emulator or deployed scheduler, follow these steps to run the sample:
 
 1. First, activate your Python virtual environment (if you're using one):
-   ```bash
-   python -m venv venv
-   source venv/bin/activate  # On Windows, use: venv\Scripts\activate
-   ```
+  ```bash
+  python -m venv venv
+  source venv/bin/activate  # On Windows, use: venv\Scripts\activate
+  ```
 
-1.  If you're using a deployed scheduler, you need set Environment Variables. Note the scheduler endpoint can be found in the Scheduler's overview tab on Azure Portal.
-   ```bash
-   export TASKHUB=<taskhubname>
-   export ENDPOINT=<schedulerEndpoint>
-   ```
+1.  If you're using a deployed scheduler, you need set Environment Variables:
+  ```bash
+  export ENDPOINT=$(az durabletask scheduler show \
+      --resource-group my-resource-group \
+      --name my-scheduler \
+      --query "properties.endpoint" \
+      --output tsv)
+
+  export TASKHUB="my-taskhub"
+  ```
 
 1. Install the required packages:
    ```bash
@@ -106,6 +136,10 @@ Once you have set up either the emulator or deployed scheduler, follow these ste
    python client.py [number_of_items]
    ```
    You can optionally provide the number of work items as an argument. If not provided, 10 items will be used by default.
+
+## Identity-based authentication
+
+Learn how to set up [identity-based authentication](https://learn.microsoft.com/azure/azure-functions/durable/durable-task-scheduler/durable-task-scheduler-identity?tabs=df&pivots=az-cli) when you deploy the app Azure.  
 
 ## Understanding the Output
 

--- a/samples/durable-task-sdks/python/function-chaining/README.md
+++ b/samples/durable-task-sdks/python/function-chaining/README.md
@@ -23,7 +23,7 @@ This pattern is useful for:
 
 ## Configuring Durable Task Scheduler
 
-There are two ways to run this sample:
+There are two ways to run this sample locally:
 
 ### Using the Emulator (Recommended)
 

--- a/samples/durable-task-sdks/python/function-chaining/README.md
+++ b/samples/durable-task-sdks/python/function-chaining/README.md
@@ -18,7 +18,7 @@ This pattern is useful for:
 ## Prerequisites
 
 1. [Python 3.9+](https://www.python.org/downloads/)
-2. [Docker](https://www.docker.com/products/docker-desktop/) (for running the emulator)
+2. [Docker](https://www.docker.com/products/docker-desktop/) (for running the emulator) installed
 3. [Azure CLI](https://docs.microsoft.com/cli/azure/install-azure-cli) (if using a deployed Durable Task Scheduler)
 
 ## Configuring Durable Task Scheduler

--- a/samples/durable-task-sdks/python/function-chaining/README.md
+++ b/samples/durable-task-sdks/python/function-chaining/README.md
@@ -29,17 +29,15 @@ There are two ways to run this sample:
 
 The emulator simulates a scheduler and taskhub in a Docker container, making it ideal for development and learning.
 
-1. Install Docker if it's not already installed.
+1. Pull the Docker Image for the Emulator:
+   ```bash
+   docker pull mcr.microsoft.com/dts/dts-emulator:latest
+   ```
 
-2. Pull the Docker Image for the Emulator:
-```bash
-docker pull mcr.microsoft.com/dts/dts-emulator:latest
-```
-
-3. Run the Emulator:
-```bash
-docker run --name dtsemulator -d -p 8080:8080 -p 8082:8082 mcr.microsoft.com/dts/dts-emulator:latest
-```
+1. Run the Emulator:
+   ```bash
+   docker run --name dtsemulator -d -p 8080:8080 -p 8082:8082 mcr.microsoft.com/dts/dts-emulator:latest
+   ```
 Wait a few seconds for the container to be ready.
 
 Note: The example code automatically uses the default emulator settings (endpoint: http://localhost:8080, taskhub: default). You don't need to set any environment variables.
@@ -48,62 +46,64 @@ Note: The example code automatically uses the default emulator settings (endpoin
 
 For production scenarios or when you're ready to deploy to Azure:
 
+1. Find regions that support the Durable Task Scheduler: 
+  ```bash
+  az provider show --namespace Microsoft.DurableTask --query "resourceTypes[?resourceType=='schedulers'].locations | [0]" --out table
+  ```
+
 1. Create a Scheduler using the Azure CLI:
-```bash
-az durabletask scheduler create --resource-group <testrg> --name <testscheduler> --location <eastus> --ip-allowlist "[0.0.0.0/0]" --sku-capacity 1 --sku-name "Dedicated" --tags "{'myattribute':'myvalue'}"
-```
+  ```bash
+  az durabletask scheduler create --resource-group <resource-group> --name <scheduler-name> --location <location> --ip-allowlist "[0.0.0.0/0]" --sku-capacity 1 --sku-name "Dedicated" --tags "{'myattribute':'myvalue'}"
+  ```
 
-2. Create Your Taskhub:
-```bash
-az durabletask taskhub create --resource-group <testrg> --scheduler-name <testscheduler> --name <testtaskhub>
-```
+1. Create Your Taskhub:
+  ```bash
+  az durabletask taskhub create --resource-group <resource-group> --scheduler-name <scheduler-name> --name <taskhub-name>
+  ```
 
-3. Retrieve the Endpoint for the Scheduler from the Azure portal.
+1. Assign your identity access to the task hub: 
+    ```bash
+    assignee=$(az ad user show --id "someone@microsoft.com" --query "id" --output tsv)
 
-4. Set the Environment Variables:
+    scope="/subscriptions/<subscription-id>/resourceGroups/<resource-group>/providers/Microsoft.DurableTask/schedulers/<scheduler-name>/taskHubs/<taskhub-name>"
 
-   Bash:
-   ```bash
-   export TASKHUB=<taskhubname>
-   export ENDPOINT=<taskhubEndpoint>
-   ```
-
-   PowerShell:
-   ```powershell
-   $env:TASKHUB = "<taskhubname>"
-   $env:ENDPOINT = "<taskhubEndpoint>"
-   ```
+    az role assignment create --assignee "$assignee" --role "Durable Task Data Contributor" --scope "$scope"
+    ```
 
 ## How to Run the Sample
-
-There are two ways to run this sample: locally or deployed to Azure.
-
-### Running Locally
 
 Once you have set up either the emulator or deployed scheduler, follow these steps to run the sample:
 
 1. First, activate your Python virtual environment (if you're using one):
-```bash
-python -m venv venv
-source venv/bin/activate  # On Windows, use: venv\Scripts\activate
-```
+   ```bash
+   python -m venv venv
+   source venv/bin/activate  # On Windows, use: venv\Scripts\activate
+   ```
 
-2. Install the required packages:
-```bash
-pip install -r requirements.txt
-```
+1.  If you're using a deployed scheduler, you need set Environment Variables. Note the scheduler endpoint can be found in the Scheduler's overview tab on Azure Portal.
+   ```bash
+   export TASKHUB=<taskhubname>
+   export ENDPOINT=<schedulerEndpoint>
+   ```
 
-3. Start the worker in a terminal:
-```bash
-python worker.py
-```
-You should see output indicating the worker has started and registered the orchestration and activities.
+1. Install the required packages:
+   ```bash
+   pip install -r requirements.txt
+   ```
 
-4. In a new terminal (with the virtual environment activated if applicable), run the client:
-```bash
-python client.py [name]
-```
-You can optionally provide a name as an argument. If not provided, "User" will be used.
+1. Start the worker in a terminal:
+   ```bash
+   python worker.py
+   ```
+   You should see output indicating the worker has started and registered the orchestration and activities.
+
+1. In a new terminal (with the virtual environment activated if applicable), run the client:
+  > **Note:** Remember to set the environment variables again if you're using a deployed scheduler. 
+
+   ```bash
+   python client.py [name]
+   ```
+   You can optionally provide a name as an argument. If not provided, "User" will be used.
 
 ### Deploying with Azure Developer CLI (AZD)
 

--- a/samples/durable-task-sdks/python/function-chaining/README.md
+++ b/samples/durable-task-sdks/python/function-chaining/README.md
@@ -30,44 +30,69 @@ There are two ways to run this sample:
 The emulator simulates a scheduler and taskhub in a Docker container, making it ideal for development and learning.
 
 1. Pull the Docker Image for the Emulator:
-   ```bash
-   docker pull mcr.microsoft.com/dts/dts-emulator:latest
-   ```
+  ```bash
+  docker pull mcr.microsoft.com/dts/dts-emulator:latest
+  ```
 
 1. Run the Emulator:
-   ```bash
-   docker run --name dtsemulator -d -p 8080:8080 -p 8082:8082 mcr.microsoft.com/dts/dts-emulator:latest
-   ```
+  ```bash
+  docker run --name dtsemulator -d -p 8080:8080 -p 8082:8082 mcr.microsoft.com/dts/dts-emulator:latest
+  ```
 Wait a few seconds for the container to be ready.
 
 Note: The example code automatically uses the default emulator settings (endpoint: http://localhost:8080, taskhub: default). You don't need to set any environment variables.
 
 ### Using a Deployed Scheduler and Taskhub in Azure
 
-For production scenarios or when you're ready to deploy to Azure:
+Local development with a deployed scheduler:
 
-1. Find regions that support the Durable Task Scheduler: 
-  ```bash
-  az provider show --namespace Microsoft.DurableTask --query "resourceTypes[?resourceType=='schedulers'].locations | [0]" --out table
-  ```
+1. Install the durable task scheduler CLI extension:
 
-1. Create a Scheduler using the Azure CLI:
-  ```bash
-  az durabletask scheduler create --resource-group <resource-group> --name <scheduler-name> --location <location> --ip-allowlist "[0.0.0.0/0]" --sku-capacity 1 --sku-name "Dedicated" --tags "{'myattribute':'myvalue'}"
-  ```
-
-1. Create Your Taskhub:
-  ```bash
-  az durabletask taskhub create --resource-group <resource-group> --scheduler-name <scheduler-name> --name <taskhub-name>
-  ```
-
-1. Assign your identity access to the task hub: 
     ```bash
-    assignee=$(az ad user show --id "someone@microsoft.com" --query "id" --output tsv)
+    az upgrade
+    az extension add --name durabletask --allow-preview true
+    ```
 
-    scope="/subscriptions/<subscription-id>/resourceGroups/<resource-group>/providers/Microsoft.DurableTask/schedulers/<scheduler-name>/taskHubs/<taskhub-name>"
+1. Create a resource group in a region where the Durable Task Scheduler is available:
 
-    az role assignment create --assignee "$assignee" --role "Durable Task Data Contributor" --scope "$scope"
+    ```bash
+    az provider show --namespace Microsoft.DurableTask --query "resourceTypes[?resourceType=='schedulers'].locations | [0]" --out table
+    ```
+
+    ```bash
+    az group create --name my-resource-group --location <location>
+    ```
+1. Create a durable task scheduler resource:
+
+    ```bash
+    az durabletask scheduler create \
+        --resource-group my-resource-group \
+        --name my-scheduler \
+        --ip-allowlist '["0.0.0.0/0"]' \
+        --sku-name "Dedicated" \
+        --sku-capacity 1 \
+        --tags "{'myattribute':'myvalue'}"
+    ```
+
+1. Create a task hub within the scheduler resource:
+
+    ```bash
+    az durabletask taskhub create \
+        --resource-group my-resource-group \
+        --scheduler-name my-scheduler \
+        --name "my-taskhub"
+    ```
+
+1. Grant the current user permission to connect to the `my-taskhub` task hub:
+
+    ```bash
+    subscriptionId=$(az account show --query "id" -o tsv)
+    loggedInUser=$(az account show --query "user.name" -o tsv)
+
+    az role assignment create \
+        --assignee $loggedInUser \
+        --role "Durable Task Data Contributor" \
+        --scope "/subscriptions/$subscriptionId/resourceGroups/my-resource-group/providers/Microsoft.DurableTask/schedulers/my-scheduler/taskHubs/my-taskhub"
     ```
 
 ## How to Run the Sample
@@ -75,16 +100,21 @@ For production scenarios or when you're ready to deploy to Azure:
 Once you have set up either the emulator or deployed scheduler, follow these steps to run the sample:
 
 1. First, activate your Python virtual environment (if you're using one):
-   ```bash
-   python -m venv venv
-   source venv/bin/activate  # On Windows, use: venv\Scripts\activate
-   ```
+  ```bash
+  python -m venv venv
+  source venv/bin/activate  # On Windows, use: venv\Scripts\activate
+  ```
 
-1.  If you're using a deployed scheduler, you need set Environment Variables. Note the scheduler endpoint can be found in the Scheduler's overview tab on Azure Portal.
-   ```bash
-   export TASKHUB=<taskhubname>
-   export ENDPOINT=<schedulerEndpoint>
-   ```
+1.  If you're using a deployed scheduler, you need set Environment Variables:
+  ```bash
+  export ENDPOINT=$(az durabletask scheduler show \
+      --resource-group my-resource-group \
+      --name my-scheduler \
+      --query "properties.endpoint" \
+      --output tsv)
+
+  export TASKHUB="my-taskhub"
+  ```
 
 1. Install the required packages:
    ```bash
@@ -105,11 +135,11 @@ Once you have set up either the emulator or deployed scheduler, follow these ste
    ```
    You can optionally provide a name as an argument. If not provided, "User" will be used.
 
-### Deploying with Azure Developer CLI (AZD)
+## Deploying with Azure Developer CLI (AZD)
 
 This sample includes an `azure.yaml` configuration file that allows you to deploy the entire solution to Azure using Azure Developer CLI (AZD).
 
-#### Prerequisites for AZD Deployment
+### Prerequisites for AZD Deployment
 
 1. Install [Azure Developer CLI](https://learn.microsoft.com/en-us/azure/developer/azure-developer-cli/install-azd)
 2. Authenticate with Azure:
@@ -117,7 +147,7 @@ This sample includes an `azure.yaml` configuration file that allows you to deplo
    azd auth login
    ```
 
-#### Deployment Steps
+### Deployment Steps
 
 1. Navigate to the Function Chaining sample directory:
    ```bash

--- a/samples/durable-task-sdks/python/human-interaction/README.md
+++ b/samples/durable-task-sdks/python/human-interaction/README.md
@@ -31,65 +31,91 @@ There are two ways to run this sample:
 The emulator simulates a scheduler and taskhub in a Docker container, making it ideal for development and learning.
 
 1. Pull the Docker Image for the Emulator:
-   ```bash
-   docker pull mcr.microsoft.com/dts/dts-emulator:latest
-   ```
+  ```bash
+  docker pull mcr.microsoft.com/dts/dts-emulator:latest
+  ```
 
 1. Run the Emulator:
-   ```bash
-   docker run --name dtsemulator -d -p 8080:8080 -p 8082:8082 mcr.microsoft.com/dts/dts-emulator:latest
-   ```
+  ```bash
+  docker run --name dtsemulator -d -p 8080:8080 -p 8082:8082 mcr.microsoft.com/dts/dts-emulator:latest
+  ```
 Wait a few seconds for the container to be ready.
 
 Note: The example code automatically uses the default emulator settings (endpoint: http://localhost:8080, taskhub: default). You don't need to set any environment variables.
 
 ### Using a Deployed Scheduler and Taskhub in Azure
 
-For production scenarios or when you're ready to deploy to Azure:
+Local development with a deployed scheduler:
 
-1. Find regions that support the Durable Task Scheduler: 
-  ```bash
-  az provider show --namespace Microsoft.DurableTask --query "resourceTypes[?resourceType=='schedulers'].locations | [0]" --out table
-  ```
+1. Install the durable task scheduler CLI extension:
 
-1. Create a Scheduler using the Azure CLI:
-  ```bash
-  az durabletask scheduler create --resource-group <resource-group> --name <scheduler-name> --location <location> --ip-allowlist "[0.0.0.0/0]" --sku-capacity 1 --sku-name "Dedicated" --tags "{'myattribute':'myvalue'}"
-  ```
-
-1. Create Your Taskhub:
-  ```bash
-  az durabletask taskhub create --resource-group <resource-group> --scheduler-name <scheduler-name> --name <taskhub-name>
-  ```
-
-1. Assign your identity access to the task hub: 
     ```bash
-    assignee=$(az ad user show --id "someone@microsoft.com" --query "id" --output tsv)
-
-    scope="/subscriptions/<subscription-id>/resourceGroups/<resource-group>/providers/Microsoft.DurableTask/schedulers/<scheduler-name>/taskHubs/<taskhub-name>"
-
-    az role assignment create --assignee "$assignee" --role "Durable Task Data Contributor" --scope "$scope"
+    az upgrade
+    az extension add --name durabletask --allow-preview true
     ```
+
+1. Create a resource group in a region where the Durable Task Scheduler is available:
+
+    ```bash
+    az provider show --namespace Microsoft.DurableTask --query "resourceTypes[?resourceType=='schedulers'].locations | [0]" --out table
+    ```
+
+    ```bash
+    az group create --name my-resource-group --location <location>
+    ```
+1. Create a durable task scheduler resource:
+
+    ```bash
+    az durabletask scheduler create \
+        --resource-group my-resource-group \
+        --name my-scheduler \
+        --ip-allowlist '["0.0.0.0/0"]' \
+        --sku-name "Dedicated" \
+        --sku-capacity 1 \
+        --tags "{'myattribute':'myvalue'}"
+    ```
+
+1. Create a task hub within the scheduler resource:
+
+    ```bash
+    az durabletask taskhub create \
+        --resource-group my-resource-group \
+        --scheduler-name my-scheduler \
+        --name "my-taskhub"
+    ```
+
+1. Grant the current user permission to connect to the `my-taskhub` task hub:
+
+    ```bash
+    subscriptionId=$(az account show --query "id" -o tsv)
+    loggedInUser=$(az account show --query "user.name" -o tsv)
+
+    az role assignment create \
+        --assignee $loggedInUser \
+        --role "Durable Task Data Contributor" \
+        --scope "/subscriptions/$subscriptionId/resourceGroups/my-resource-group/providers/Microsoft.DurableTask/schedulers/my-scheduler/taskHubs/my-taskhub"
+    ```
+
 ## How to Run the Sample
 
 Once you have set up either the emulator or deployed scheduler, follow these steps to run the sample:
 
 1. First, activate your Python virtual environment (if you're using one):
-   ```bash
-   python -m venv venv
-   source venv/bin/activate  # On Windows, use: venv\Scripts\activate
-   ```
+  ```bash
+  python -m venv venv
+  source venv/bin/activate  # On Windows, use: venv\Scripts\activate
+  ```
 
-1.  If you're using a deployed scheduler, you need set Environment Variables. Note the scheduler endpoint can be found in the Scheduler's overview tab on Azure Portal.
-   ```bash
-   export TASKHUB=<taskhubname>
-   export ENDPOINT=<schedulerEndpoint>
-   ```
+1.  If you're using a deployed scheduler, you need set Environment Variables:
+  ```bash
+  export ENDPOINT=$(az durabletask scheduler show \
+      --resource-group my-resource-group \
+      --name my-scheduler \
+      --query "properties.endpoint" \
+      --output tsv)
 
-1. Install the required packages:
-   ```bash
-   pip install -r requirements.txt
-   ```
+  export TASKHUB="my-taskhub"
+  ```
 
 1. Start the worker in a terminal:
    ```bash
@@ -104,6 +130,11 @@ Once you have set up either the emulator or deployed scheduler, follow these ste
    python client.py
    ```
    This will launch an interactive console client that creates an approval request and waits for your response.
+
+## Identity-based authentication
+
+Learn how to set up [identity-based authentication](https://learn.microsoft.com/azure/azure-functions/durable/durable-task-scheduler/durable-task-scheduler-identity?tabs=df&pivots=az-cli) when you deploy the app Azure.  
+
 
 ## Understanding the Output
 

--- a/samples/durable-task-sdks/python/human-interaction/README.md
+++ b/samples/durable-task-sdks/python/human-interaction/README.md
@@ -24,7 +24,7 @@ This pattern is useful for:
 
 ## Configuring Durable Task Scheduler
 
-There are two ways to run this sample:
+There are two ways to run this sample locally:
 
 ### Using the Emulator (Recommended)
 

--- a/samples/durable-task-sdks/python/human-interaction/README.md
+++ b/samples/durable-task-sdks/python/human-interaction/README.md
@@ -19,7 +19,7 @@ This pattern is useful for:
 ## Prerequisites
 
 1. [Python 3.9+](https://www.python.org/downloads/)
-2. [Docker](https://www.docker.com/products/docker-desktop/) (for running the emulator)
+2. [Docker](https://www.docker.com/products/docker-desktop/) (for running the emulator) installed
 3. [Azure CLI](https://docs.microsoft.com/cli/azure/install-azure-cli) (if using a deployed Durable Task Scheduler)
 
 ## Configuring Durable Task Scheduler

--- a/samples/durable-task-sdks/python/human-interaction/README.md
+++ b/samples/durable-task-sdks/python/human-interaction/README.md
@@ -30,17 +30,15 @@ There are two ways to run this sample:
 
 The emulator simulates a scheduler and taskhub in a Docker container, making it ideal for development and learning.
 
-1. Install Docker if it's not already installed.
+1. Pull the Docker Image for the Emulator:
+   ```bash
+   docker pull mcr.microsoft.com/dts/dts-emulator:latest
+   ```
 
-2. Pull the Docker Image for the Emulator:
-```bash
-docker pull mcr.microsoft.com/dts/dts-emulator:latest
-```
-
-3. Run the Emulator:
-```bash
-docker run --name dtsemulator -d -p 8080:8080 -p 8082:8082 mcr.microsoft.com/dts/dts-emulator:latest
-```
+1. Run the Emulator:
+   ```bash
+   docker run --name dtsemulator -d -p 8080:8080 -p 8082:8082 mcr.microsoft.com/dts/dts-emulator:latest
+   ```
 Wait a few seconds for the container to be ready.
 
 Note: The example code automatically uses the default emulator settings (endpoint: http://localhost:8080, taskhub: default). You don't need to set any environment variables.
@@ -49,58 +47,63 @@ Note: The example code automatically uses the default emulator settings (endpoin
 
 For production scenarios or when you're ready to deploy to Azure:
 
+1. Find regions that support the Durable Task Scheduler: 
+  ```bash
+  az provider show --namespace Microsoft.DurableTask --query "resourceTypes[?resourceType=='schedulers'].locations | [0]" --out table
+  ```
+
 1. Create a Scheduler using the Azure CLI:
-```bash
-az durabletask scheduler create --resource-group <testrg> --name <testscheduler> --location <eastus> --ip-allowlist "[0.0.0.0/0]" --sku-capacity 1 --sku-name "Dedicated" --tags "{'myattribute':'myvalue'}"
-```
+  ```bash
+  az durabletask scheduler create --resource-group <resource-group> --name <scheduler-name> --location <location> --ip-allowlist "[0.0.0.0/0]" --sku-capacity 1 --sku-name "Dedicated" --tags "{'myattribute':'myvalue'}"
+  ```
 
-2. Create Your Taskhub:
-```bash
-az durabletask taskhub create --resource-group <testrg> --scheduler-name <testscheduler> --name <testtaskhub>
-```
+1. Create Your Taskhub:
+  ```bash
+  az durabletask taskhub create --resource-group <resource-group> --scheduler-name <scheduler-name> --name <taskhub-name>
+  ```
 
-3. Retrieve the Endpoint for the Scheduler from the Azure portal.
+1. Assign your identity access to the task hub: 
+    ```bash
+    assignee=$(az ad user show --id "someone@microsoft.com" --query "id" --output tsv)
 
-4. Set the Environment Variables:
+    scope="/subscriptions/<subscription-id>/resourceGroups/<resource-group>/providers/Microsoft.DurableTask/schedulers/<scheduler-name>/taskHubs/<taskhub-name>"
 
-   Bash:
-   ```bash
-   export TASKHUB=<taskhubname>
-   export ENDPOINT=<taskhubEndpoint>
-   ```
-
-   PowerShell:
-   ```powershell
-   $env:TASKHUB = "<taskhubname>"
-   $env:ENDPOINT = "<taskhubEndpoint>"
-   ```
-
+    az role assignment create --assignee "$assignee" --role "Durable Task Data Contributor" --scope "$scope"
+    ```
 ## How to Run the Sample
 
 Once you have set up either the emulator or deployed scheduler, follow these steps to run the sample:
 
 1. First, activate your Python virtual environment (if you're using one):
-```bash
-python -m venv venv
-source venv/bin/activate  # On Windows, use: venv\Scripts\activate
-```
+   ```bash
+   python -m venv venv
+   source venv/bin/activate  # On Windows, use: venv\Scripts\activate
+   ```
 
-2. Install the required packages:
-```bash
-pip install -r requirements.txt
-```
+1.  If you're using a deployed scheduler, you need set Environment Variables. Note the scheduler endpoint can be found in the Scheduler's overview tab on Azure Portal.
+   ```bash
+   export TASKHUB=<taskhubname>
+   export ENDPOINT=<schedulerEndpoint>
+   ```
 
-3. Start the worker in a terminal:
-```bash
-python worker.py
-```
-You should see output indicating the worker has started and registered the orchestration and activities.
+1. Install the required packages:
+   ```bash
+   pip install -r requirements.txt
+   ```
 
-4. In a new terminal (with the virtual environment activated if applicable), run the client:
-```bash
-python client.py
-```
-This will launch an interactive console client that creates an approval request and waits for your response.
+1. Start the worker in a terminal:
+   ```bash
+   python worker.py
+   ```
+   You should see output indicating the worker has started and registered the orchestration and activities.
+
+1. In a new terminal (with the virtual environment activated if applicable), run the client:
+  > **Note:** Remember to set the environment variables again if you're using a deployed scheduler. 
+
+   ```bash
+   python client.py
+   ```
+   This will launch an interactive console client that creates an approval request and waits for your response.
 
 ## Understanding the Output
 

--- a/samples/durable-task-sdks/python/monitoring/README.md
+++ b/samples/durable-task-sdks/python/monitoring/README.md
@@ -26,7 +26,7 @@ This pattern is useful for:
 
 ## Configuring Durable Task Scheduler
 
-There are two ways to run this sample:
+There are two ways to run this sample locally:
 
 ### Using the Emulator (Recommended)
 

--- a/samples/durable-task-sdks/python/monitoring/README.md
+++ b/samples/durable-task-sdks/python/monitoring/README.md
@@ -21,7 +21,7 @@ This pattern is useful for:
 ## Prerequisites
 
 1. [Python 3.9+](https://www.python.org/downloads/)
-2. [Docker](https://www.docker.com/products/docker-desktop/) (for running the emulator)
+2. [Docker](https://www.docker.com/products/docker-desktop/) (for running the emulator) installed
 3. [Azure CLI](https://docs.microsoft.com/cli/azure/install-azure-cli) (if using a deployed Durable Task Scheduler)
 
 ## Configuring Durable Task Scheduler
@@ -32,17 +32,15 @@ There are two ways to run this sample:
 
 The emulator simulates a scheduler and taskhub in a Docker container, making it ideal for development and learning.
 
-1. Install Docker if it's not already installed.
+1. Pull the Docker Image for the Emulator:
+   ```bash
+   docker pull mcr.microsoft.com/dts/dts-emulator:latest
+   ```
 
-2. Pull the Docker Image for the Emulator:
-```bash
-docker pull mcr.microsoft.com/dts/dts-emulator:latest
-```
-
-3. Run the Emulator:
-```bash
-docker run --name dtsemulator -d -p 8080:8080 -p 8082:8082 mcr.microsoft.com/dts/dts-emulator:latest
-```
+1. Run the Emulator:
+   ```bash
+   docker run --name dtsemulator -d -p 8080:8080 -p 8082:8082 mcr.microsoft.com/dts/dts-emulator:latest
+   ```
 Wait a few seconds for the container to be ready.
 
 Note: The example code automatically uses the default emulator settings (endpoint: http://localhost:8080, taskhub: default). You don't need to set any environment variables.
@@ -51,61 +49,67 @@ Note: The example code automatically uses the default emulator settings (endpoin
 
 For production scenarios or when you're ready to deploy to Azure:
 
+1. Find regions that support the Durable Task Scheduler: 
+  ```bash
+  az provider show --namespace Microsoft.DurableTask --query "resourceTypes[?resourceType=='schedulers'].locations | [0]" --out table
+  ```
+
 1. Create a Scheduler using the Azure CLI:
-```bash
-az durabletask scheduler create --resource-group <testrg> --name <testscheduler> --location <eastus> --ip-allowlist "[0.0.0.0/0]" --sku-capacity 1 --sku-name "Dedicated" --tags "{'myattribute':'myvalue'}"
-```
+  ```bash
+  az durabletask scheduler create --resource-group <resource-group> --name <scheduler-name> --location <location> --ip-allowlist "[0.0.0.0/0]" --sku-capacity 1 --sku-name "Dedicated" --tags "{'myattribute':'myvalue'}"
+  ```
 
-2. Create Your Taskhub:
-```bash
-az durabletask taskhub create --resource-group <testrg> --scheduler-name <testscheduler> --name <testtaskhub>
-```
+1. Create Your Taskhub:
+  ```bash
+  az durabletask taskhub create --resource-group <resource-group> --scheduler-name <scheduler-name> --name <taskhub-name>
+  ```
 
-3. Retrieve the Endpoint for the Scheduler from the Azure portal.
+1. Assign your identity access to the task hub: 
+    ```bash
+    assignee=$(az ad user show --id "someone@microsoft.com" --query "id" --output tsv)
 
-4. Set the Environment Variables:
+    scope="/subscriptions/<subscription-id>/resourceGroups/<resource-group>/providers/Microsoft.DurableTask/schedulers/<scheduler-name>/taskHubs/<taskhub-name>"
 
-   Bash:
-   ```bash
-   export TASKHUB=<taskhubname>
-   export ENDPOINT=<taskhubEndpoint>
-   ```
-
-   PowerShell:
-   ```powershell
-   $env:TASKHUB = "<taskhubname>"
-   $env:ENDPOINT = "<taskhubEndpoint>"
-   ```
+    az role assignment create --assignee "$assignee" --role "Durable Task Data Contributor" --scope "$scope"
+    ```
 
 ## How to Run the Sample
 
 Once you have set up either the emulator or deployed scheduler, follow these steps to run the sample:
 
 1. First, activate your Python virtual environment (if you're using one):
-```bash
-python -m venv venv
-source venv/bin/activate  # On Windows, use: venv\Scripts\activate
-```
+   ```bash
+   python -m venv venv
+   source venv/bin/activate  # On Windows, use: venv\Scripts\activate
+   ```
 
-2. Install the required packages:
-```bash
-pip install -r requirements.txt
-```
+1.  If you're using a deployed scheduler, you need set Environment Variables. Note the scheduler endpoint can be found in the Scheduler's overview tab on Azure Portal.
+   ```bash
+   export TASKHUB=<taskhubname>
+   export ENDPOINT=<schedulerEndpoint>
+   ```
 
-3. Start the worker in a terminal:
-```bash
-python worker.py
-```
-You should see output indicating the worker has started and registered the orchestration and activities.
+1. Install the required packages:
+   ```bash
+   pip install -r requirements.txt
+   ```
 
-4. In a new terminal (with the virtual environment activated if applicable), run the client:
-```bash
-python client.py [job_id] [polling_interval] [timeout]
-```
-You can optionally provide:
-- `job_id`: A unique identifier for the job (defaults to a random UUID)
-- `polling_interval`: How often to check job status in seconds (defaults to 5)
-- `timeout`: Maximum monitoring duration in seconds (defaults to 30)
+1. Start the worker in a terminal:
+   ```bash
+   python worker.py
+   ```
+   You should see output indicating the worker has started and registered the orchestration and activities.
+
+1. In a new terminal (with the virtual environment activated if applicable), run the client:
+  > **Note:** Remember to set the environment variables again if you're using a deployed scheduler. 
+  
+   ```bash
+   python client.py [job_id] [polling_interval] [timeout]
+   ```
+   You can optionally provide:
+   - `job_id`: A unique identifier for the job (defaults to a random UUID)
+   - `polling_interval`: How often to check job status in seconds (defaults to 5)
+   - `timeout`: Maximum monitoring duration in seconds (defaults to 30)
 
 ## Understanding the Output
 

--- a/samples/durable-task-sdks/python/monitoring/README.md
+++ b/samples/durable-task-sdks/python/monitoring/README.md
@@ -33,44 +33,69 @@ There are two ways to run this sample:
 The emulator simulates a scheduler and taskhub in a Docker container, making it ideal for development and learning.
 
 1. Pull the Docker Image for the Emulator:
-   ```bash
-   docker pull mcr.microsoft.com/dts/dts-emulator:latest
-   ```
+  ```bash
+  docker pull mcr.microsoft.com/dts/dts-emulator:latest
+  ```
 
 1. Run the Emulator:
-   ```bash
-   docker run --name dtsemulator -d -p 8080:8080 -p 8082:8082 mcr.microsoft.com/dts/dts-emulator:latest
-   ```
+  ```bash
+  docker run --name dtsemulator -d -p 8080:8080 -p 8082:8082 mcr.microsoft.com/dts/dts-emulator:latest
+  ```
 Wait a few seconds for the container to be ready.
 
 Note: The example code automatically uses the default emulator settings (endpoint: http://localhost:8080, taskhub: default). You don't need to set any environment variables.
 
 ### Using a Deployed Scheduler and Taskhub in Azure
 
-For production scenarios or when you're ready to deploy to Azure:
+Local development with a deployed scheduler:
 
-1. Find regions that support the Durable Task Scheduler: 
-  ```bash
-  az provider show --namespace Microsoft.DurableTask --query "resourceTypes[?resourceType=='schedulers'].locations | [0]" --out table
-  ```
+1. Install the durable task scheduler CLI extension:
 
-1. Create a Scheduler using the Azure CLI:
-  ```bash
-  az durabletask scheduler create --resource-group <resource-group> --name <scheduler-name> --location <location> --ip-allowlist "[0.0.0.0/0]" --sku-capacity 1 --sku-name "Dedicated" --tags "{'myattribute':'myvalue'}"
-  ```
-
-1. Create Your Taskhub:
-  ```bash
-  az durabletask taskhub create --resource-group <resource-group> --scheduler-name <scheduler-name> --name <taskhub-name>
-  ```
-
-1. Assign your identity access to the task hub: 
     ```bash
-    assignee=$(az ad user show --id "someone@microsoft.com" --query "id" --output tsv)
+    az upgrade
+    az extension add --name durabletask --allow-preview true
+    ```
 
-    scope="/subscriptions/<subscription-id>/resourceGroups/<resource-group>/providers/Microsoft.DurableTask/schedulers/<scheduler-name>/taskHubs/<taskhub-name>"
+1. Create a resource group in a region where the Durable Task Scheduler is available:
 
-    az role assignment create --assignee "$assignee" --role "Durable Task Data Contributor" --scope "$scope"
+    ```bash
+    az provider show --namespace Microsoft.DurableTask --query "resourceTypes[?resourceType=='schedulers'].locations | [0]" --out table
+    ```
+
+    ```bash
+    az group create --name my-resource-group --location <location>
+    ```
+1. Create a durable task scheduler resource:
+
+    ```bash
+    az durabletask scheduler create \
+        --resource-group my-resource-group \
+        --name my-scheduler \
+        --ip-allowlist '["0.0.0.0/0"]' \
+        --sku-name "Dedicated" \
+        --sku-capacity 1 \
+        --tags "{'myattribute':'myvalue'}"
+    ```
+
+1. Create a task hub within the scheduler resource:
+
+    ```bash
+    az durabletask taskhub create \
+        --resource-group my-resource-group \
+        --scheduler-name my-scheduler \
+        --name "my-taskhub"
+    ```
+
+1. Grant the current user permission to connect to the `my-taskhub` task hub:
+
+    ```bash
+    subscriptionId=$(az account show --query "id" -o tsv)
+    loggedInUser=$(az account show --query "user.name" -o tsv)
+
+    az role assignment create \
+        --assignee $loggedInUser \
+        --role "Durable Task Data Contributor" \
+        --scope "/subscriptions/$subscriptionId/resourceGroups/my-resource-group/providers/Microsoft.DurableTask/schedulers/my-scheduler/taskHubs/my-taskhub"
     ```
 
 ## How to Run the Sample
@@ -78,16 +103,21 @@ For production scenarios or when you're ready to deploy to Azure:
 Once you have set up either the emulator or deployed scheduler, follow these steps to run the sample:
 
 1. First, activate your Python virtual environment (if you're using one):
-   ```bash
-   python -m venv venv
-   source venv/bin/activate  # On Windows, use: venv\Scripts\activate
-   ```
+  ```bash
+  python -m venv venv
+  source venv/bin/activate  # On Windows, use: venv\Scripts\activate
+  ```
 
-1.  If you're using a deployed scheduler, you need set Environment Variables. Note the scheduler endpoint can be found in the Scheduler's overview tab on Azure Portal.
-   ```bash
-   export TASKHUB=<taskhubname>
-   export ENDPOINT=<schedulerEndpoint>
-   ```
+1.  If you're using a deployed scheduler, you need set Environment Variables:
+  ```bash
+  export ENDPOINT=$(az durabletask scheduler show \
+      --resource-group my-resource-group \
+      --name my-scheduler \
+      --query "properties.endpoint" \
+      --output tsv)
+
+  export TASKHUB="my-taskhub"
+  ```
 
 1. Install the required packages:
    ```bash
@@ -110,6 +140,11 @@ Once you have set up either the emulator or deployed scheduler, follow these ste
    - `job_id`: A unique identifier for the job (defaults to a random UUID)
    - `polling_interval`: How often to check job status in seconds (defaults to 5)
    - `timeout`: Maximum monitoring duration in seconds (defaults to 30)
+
+## Identity-based authentication
+
+Learn how to set up [identity-based authentication](https://learn.microsoft.com/azure/azure-functions/durable/durable-task-scheduler/durable-task-scheduler-identity?tabs=df&pivots=az-cli) when you deploy the app Azure.  
+
 
 ## Understanding the Output
 

--- a/samples/durable-task-sdks/python/sub-orchestrations/README.md
+++ b/samples/durable-task-sdks/python/sub-orchestrations/README.md
@@ -29,17 +29,15 @@ There are two ways to run this sample:
 
 The emulator simulates a scheduler and taskhub in a Docker container, making it ideal for development and learning.
 
-1. Install Docker if it's not already installed.
+1. Pull the Docker Image for the Emulator:
+   ```bash
+   docker pull mcr.microsoft.com/dts/dts-emulator:latest
+   ```
 
-2. Pull the Docker Image for the Emulator:
-```bash
-docker pull mcr.microsoft.com/dts/dts-emulator:latest
-```
-
-3. Run the Emulator:
-```bash
-docker run --name dtsemulator -d -p 8080:8080 -p 8082:8082 mcr.microsoft.com/dts/dts-emulator:latest
-```
+1. Run the Emulator:
+   ```bash
+   docker run --name dtsemulator -d -p 8080:8080 -p 8082:8082 mcr.microsoft.com/dts/dts-emulator:latest
+   ```
 Wait a few seconds for the container to be ready.
 
 Note: The example code automatically uses the default emulator settings (endpoint: http://localhost:8080, taskhub: default). You don't need to set any environment variables.
@@ -48,57 +46,64 @@ Note: The example code automatically uses the default emulator settings (endpoin
 
 For production scenarios or when you're ready to deploy to Azure:
 
+1. Find regions that support the Durable Task Scheduler: 
+  ```bash
+  az provider show --namespace Microsoft.DurableTask --query "resourceTypes[?resourceType=='schedulers'].locations | [0]" --out table
+  ```
+
 1. Create a Scheduler using the Azure CLI:
-```bash
-az durabletask scheduler create --resource-group <testrg> --name <testscheduler> --location <eastus> --ip-allowlist "[0.0.0.0/0]" --sku-capacity 1 --sku-name "Dedicated" --tags "{'myattribute':'myvalue'}"
-```
+  ```bash
+  az durabletask scheduler create --resource-group <resource-group> --name <scheduler-name> --location <location> --ip-allowlist "[0.0.0.0/0]" --sku-capacity 1 --sku-name "Dedicated" --tags "{'myattribute':'myvalue'}"
+  ```
 
-2. Create Your Taskhub:
-```bash
-az durabletask taskhub create --resource-group <testrg> --scheduler-name <testscheduler> --name <testtaskhub>
-```
+1. Create Your Taskhub:
+  ```bash
+  az durabletask taskhub create --resource-group <resource-group> --scheduler-name <scheduler-name> --name <taskhub-name>
+  ```
 
-3. Retrieve the Endpoint for the Scheduler from the Azure portal.
+1. Assign your identity access to the task hub: 
+    ```bash
+    assignee=$(az ad user show --id "someone@microsoft.com" --query "id" --output tsv)
 
-4. Set the Environment Variables:
+    scope="/subscriptions/<subscription-id>/resourceGroups/<resource-group>/providers/Microsoft.DurableTask/schedulers/<scheduler-name>/taskHubs/<taskhub-name>"
 
-   Bash:
-   ```bash
-   export TASKHUB=<taskhubname>
-   export ENDPOINT=<taskhubEndpoint>
-   ```
-
-   PowerShell:
-   ```powershell
-   $env:TASKHUB = "<taskhubname>"
-   $env:ENDPOINT = "<taskhubEndpoint>"
-   ```
+    az role assignment create --assignee "$assignee" --role "Durable Task Data Contributor" --scope "$scope"
+    ```
 
 ## How to Run the Sample
 
 Once you have set up either the emulator or deployed scheduler, follow these steps to run the sample:
 
 1. First, activate your Python virtual environment (if you're using one):
-```bash
-python -m venv venv
-source venv/bin/activate  # On Windows, use: venv\Scripts\activate
-```
+  ```bash
+  python -m venv venv
+  source venv/bin/activate  # On Windows, use: venv\Scripts\activate
+  ```
 
-2. Install the required packages:
-```bash
-pip install -r requirements.txt
-```
+1.  If you're using a deployed scheduler, you need set Environment Variables. Note the scheduler endpoint can be found in the Scheduler's overview tab on Azure Portal.
+   ```bash
+   export TASKHUB=<taskhubname>
+   export ENDPOINT=<schedulerEndpoint>
+   ```
 
-3. Start the worker in a terminal:
-```bash
-python worker.py
-```
-You should see output indicating the worker has started and registered the orchestration and activities.
+1. Install the required packages:
+  ```bash
+  pip install -r requirements.txt
+  ```
 
-4. In a new terminal (with the virtual environment activated if applicable), run the client:
-```bash
-python client.py
-```
+1. Start the worker in a terminal:
+  ```bash
+  python worker.py
+  ```
+   You should see output indicating the worker has started and registered the orchestration and activities.
+
+1. In a new terminal (with the virtual environment activated if applicable), run the client (which is a FastAPI server):
+  > **Note:** Remember to set the environment variables again if you're using a deployed scheduler. 
+
+  ```bash
+  python client.py
+  ```
+ 
 
 ## Understanding the Output
 

--- a/samples/durable-task-sdks/python/sub-orchestrations/README.md
+++ b/samples/durable-task-sdks/python/sub-orchestrations/README.md
@@ -18,7 +18,7 @@ Sub-orchestrations are useful for:
 ## Prerequisites
 
 1. [Python 3.9+](https://www.python.org/downloads/)
-2. [Docker](https://www.docker.com/products/docker-desktop/) (for running the emulator)
+2. [Docker](https://www.docker.com/products/docker-desktop/) (for running the emulator) installed
 3. [Azure CLI](https://docs.microsoft.com/cli/azure/install-azure-cli) (if using a deployed Durable Task Scheduler)
 
 ## Configuring Durable Task Scheduler

--- a/samples/durable-task-sdks/python/sub-orchestrations/README.md
+++ b/samples/durable-task-sdks/python/sub-orchestrations/README.md
@@ -30,44 +30,69 @@ There are two ways to run this sample:
 The emulator simulates a scheduler and taskhub in a Docker container, making it ideal for development and learning.
 
 1. Pull the Docker Image for the Emulator:
-   ```bash
-   docker pull mcr.microsoft.com/dts/dts-emulator:latest
-   ```
+  ```bash
+  docker pull mcr.microsoft.com/dts/dts-emulator:latest
+  ```
 
 1. Run the Emulator:
-   ```bash
-   docker run --name dtsemulator -d -p 8080:8080 -p 8082:8082 mcr.microsoft.com/dts/dts-emulator:latest
-   ```
+  ```bash
+  docker run --name dtsemulator -d -p 8080:8080 -p 8082:8082 mcr.microsoft.com/dts/dts-emulator:latest
+  ```
 Wait a few seconds for the container to be ready.
 
 Note: The example code automatically uses the default emulator settings (endpoint: http://localhost:8080, taskhub: default). You don't need to set any environment variables.
 
 ### Using a Deployed Scheduler and Taskhub in Azure
 
-For production scenarios or when you're ready to deploy to Azure:
+Local development with a deployed scheduler:
 
-1. Find regions that support the Durable Task Scheduler: 
-  ```bash
-  az provider show --namespace Microsoft.DurableTask --query "resourceTypes[?resourceType=='schedulers'].locations | [0]" --out table
-  ```
+1. Install the durable task scheduler CLI extension:
 
-1. Create a Scheduler using the Azure CLI:
-  ```bash
-  az durabletask scheduler create --resource-group <resource-group> --name <scheduler-name> --location <location> --ip-allowlist "[0.0.0.0/0]" --sku-capacity 1 --sku-name "Dedicated" --tags "{'myattribute':'myvalue'}"
-  ```
-
-1. Create Your Taskhub:
-  ```bash
-  az durabletask taskhub create --resource-group <resource-group> --scheduler-name <scheduler-name> --name <taskhub-name>
-  ```
-
-1. Assign your identity access to the task hub: 
     ```bash
-    assignee=$(az ad user show --id "someone@microsoft.com" --query "id" --output tsv)
+    az upgrade
+    az extension add --name durabletask --allow-preview true
+    ```
 
-    scope="/subscriptions/<subscription-id>/resourceGroups/<resource-group>/providers/Microsoft.DurableTask/schedulers/<scheduler-name>/taskHubs/<taskhub-name>"
+1. Create a resource group in a region where the Durable Task Scheduler is available:
 
-    az role assignment create --assignee "$assignee" --role "Durable Task Data Contributor" --scope "$scope"
+    ```bash
+    az provider show --namespace Microsoft.DurableTask --query "resourceTypes[?resourceType=='schedulers'].locations | [0]" --out table
+    ```
+
+    ```bash
+    az group create --name my-resource-group --location <location>
+    ```
+1. Create a durable task scheduler resource:
+
+    ```bash
+    az durabletask scheduler create \
+        --resource-group my-resource-group \
+        --name my-scheduler \
+        --ip-allowlist '["0.0.0.0/0"]' \
+        --sku-name "Dedicated" \
+        --sku-capacity 1 \
+        --tags "{'myattribute':'myvalue'}"
+    ```
+
+1. Create a task hub within the scheduler resource:
+
+    ```bash
+    az durabletask taskhub create \
+        --resource-group my-resource-group \
+        --scheduler-name my-scheduler \
+        --name "my-taskhub"
+    ```
+
+1. Grant the current user permission to connect to the `my-taskhub` task hub:
+
+    ```bash
+    subscriptionId=$(az account show --query "id" -o tsv)
+    loggedInUser=$(az account show --query "user.name" -o tsv)
+
+    az role assignment create \
+        --assignee $loggedInUser \
+        --role "Durable Task Data Contributor" \
+        --scope "/subscriptions/$subscriptionId/resourceGroups/my-resource-group/providers/Microsoft.DurableTask/schedulers/my-scheduler/taskHubs/my-taskhub"
     ```
 
 ## How to Run the Sample
@@ -80,15 +105,15 @@ Once you have set up either the emulator or deployed scheduler, follow these ste
   source venv/bin/activate  # On Windows, use: venv\Scripts\activate
   ```
 
-1.  If you're using a deployed scheduler, you need set Environment Variables. Note the scheduler endpoint can be found in the Scheduler's overview tab on Azure Portal.
-   ```bash
-   export TASKHUB=<taskhubname>
-   export ENDPOINT=<schedulerEndpoint>
-   ```
-
-1. Install the required packages:
+1.  If you're using a deployed scheduler, you need set Environment Variables:
   ```bash
-  pip install -r requirements.txt
+  export ENDPOINT=$(az durabletask scheduler show \
+      --resource-group my-resource-group \
+      --name my-scheduler \
+      --query "properties.endpoint" \
+      --output tsv)
+
+  export TASKHUB="my-taskhub"
   ```
 
 1. Start the worker in a terminal:
@@ -104,6 +129,10 @@ Once you have set up either the emulator or deployed scheduler, follow these ste
   python client.py
   ```
  
+## Identity-based authentication
+
+Learn how to set up [identity-based authentication](https://learn.microsoft.com/azure/azure-functions/durable/durable-task-scheduler/durable-task-scheduler-identity?tabs=df&pivots=az-cli) when you deploy the app Azure.  
+
 
 ## Understanding the Output
 

--- a/samples/durable-task-sdks/python/sub-orchestrations/README.md
+++ b/samples/durable-task-sdks/python/sub-orchestrations/README.md
@@ -23,7 +23,7 @@ Sub-orchestrations are useful for:
 
 ## Configuring Durable Task Scheduler
 
-There are two ways to run this sample:
+There are two ways to run this sample locally:
 
 ### Using the Emulator (Recommended)
 


### PR DESCRIPTION
PR has changes covering:
1. Durable task SDKs Python and .NET 

Changes:
- Standardized readme for non azd samples to include
    - emulator instruction (easiest to run)
    - add instructions for assigning RBAC to developer identity
    - changed getting DTS endpoint through command (instead of going to portal)
    - add link to identity article for deployed app
- Corrected some environment variables (ENDPOINT should be scheduler endpoint, not task hub)
- Made instructions more concised when possible and added missing instructions

2. DF Hello Cities azd quickstart 
- Made instructions more concised when possible and added missing instructions

4. Order Processing azd
- Extended wait time for new IP rule to take effect 

