### PR TITLE
Update DTS API version in bicep to stable

### DIFF
--- a/quickstarts/durable-functions/dotnet/HelloCities/infra/app/dts-Access.bicep
+++ b/quickstarts/durable-functions/dotnet/HelloCities/infra/app/dts-Access.bicep
@@ -3,7 +3,7 @@ param roleDefinitionID string
 param dtsName string
 param principalType string
 
-resource dts 'Microsoft.DurableTask/schedulers@2024-10-01-preview' existing = {
+resource dts 'Microsoft.DurableTask/schedulers@2025-11-01' existing = {
   name: dtsName
 }
 

--- a/quickstarts/durable-functions/dotnet/HelloCities/infra/app/dts.bicep
+++ b/quickstarts/durable-functions/dotnet/HelloCities/infra/app/dts.bicep
@@ -6,7 +6,7 @@ param taskhubname string
 param skuName string 
 param skuCapacity int
 
-resource dts 'Microsoft.DurableTask/schedulers@2024-10-01-preview' = {
+resource dts 'Microsoft.DurableTask/schedulers@2025-11-01' = {
   location: location
   tags: tags
   name: name
@@ -19,7 +19,7 @@ resource dts 'Microsoft.DurableTask/schedulers@2024-10-01-preview' = {
   }
 }
 
-resource taskhub 'Microsoft.DurableTask/schedulers/taskhubs@2024-10-01-preview' = {
+resource taskhub 'Microsoft.DurableTask/schedulers/taskhubs@2025-11-01' = {
   parent: dts
   name: taskhubname
 }

--- a/samples/durable-functions/dotnet/AiAgentTravelPlanOrchestrator/infra/app/dts-Access.bicep
+++ b/samples/durable-functions/dotnet/AiAgentTravelPlanOrchestrator/infra/app/dts-Access.bicep
@@ -3,7 +3,7 @@ param roleDefinitionID string
 param dtsName string
 param principalType string
 
-resource dts 'Microsoft.DurableTask/schedulers@2024-10-01-preview' existing = {
+resource dts 'Microsoft.DurableTask/schedulers@2025-11-01' existing = {
   name: dtsName
 }
 

--- a/samples/durable-functions/dotnet/AiAgentTravelPlanOrchestrator/infra/app/dts.bicep
+++ b/samples/durable-functions/dotnet/AiAgentTravelPlanOrchestrator/infra/app/dts.bicep
@@ -6,7 +6,7 @@ param taskhubname string
 param skuName string 
 param skuCapacity int
 
-resource dts 'Microsoft.DurableTask/schedulers@2024-10-01-preview' = {
+resource dts 'Microsoft.DurableTask/schedulers@2025-11-01' = {
   location: location
   tags: tags
   name: name
@@ -19,7 +19,7 @@ resource dts 'Microsoft.DurableTask/schedulers@2024-10-01-preview' = {
   }
 }
 
-resource taskhub 'Microsoft.DurableTask/schedulers/taskhubs@2024-10-01-preview' = {
+resource taskhub 'Microsoft.DurableTask/schedulers/taskhubs@2025-11-01' = {
   parent: dts
   name: taskhubname
 }

--- a/samples/durable-functions/dotnet/OrderProcessor/infra/app/dts-Access.bicep
+++ b/samples/durable-functions/dotnet/OrderProcessor/infra/app/dts-Access.bicep
@@ -3,7 +3,7 @@ param roleDefinitionID string
 param dtsName string
 param principalType string
 
-resource dts 'Microsoft.DurableTask/schedulers@2024-10-01-preview' existing = {
+resource dts 'Microsoft.DurableTask/schedulers@2025-11-01' existing = {
   name: dtsName
 }
 

--- a/samples/durable-functions/dotnet/OrderProcessor/infra/app/dts.bicep
+++ b/samples/durable-functions/dotnet/OrderProcessor/infra/app/dts.bicep
@@ -6,7 +6,7 @@ param taskhubname string
 param skuName string 
 param skuCapacity int
 
-resource dts 'Microsoft.DurableTask/schedulers@2024-10-01-preview' = {
+resource dts 'Microsoft.DurableTask/schedulers@2025-11-01' = {
   location: location
   tags: tags
   name: name
@@ -19,7 +19,7 @@ resource dts 'Microsoft.DurableTask/schedulers@2024-10-01-preview' = {
   }
 }
 
-resource taskhub 'Microsoft.DurableTask/schedulers/taskhubs@2024-10-01-preview' = {
+resource taskhub 'Microsoft.DurableTask/schedulers/taskhubs@2025-11-01' = {
   parent: dts
   name: taskhubname
 }

--- a/samples/durable-functions/dotnet/PdfSummarizer/infra/app/dts-Access.bicep
+++ b/samples/durable-functions/dotnet/PdfSummarizer/infra/app/dts-Access.bicep
@@ -3,7 +3,7 @@ param roleDefinitionID string
 param dtsName string
 param principalType string
 
-resource dts 'Microsoft.DurableTask/schedulers@2024-10-01-preview' existing = {
+resource dts 'Microsoft.DurableTask/schedulers@2025-11-01' existing = {
   name: dtsName
 }
 

--- a/samples/durable-functions/dotnet/PdfSummarizer/infra/app/dts.bicep
+++ b/samples/durable-functions/dotnet/PdfSummarizer/infra/app/dts.bicep
@@ -6,7 +6,7 @@ param taskhubname string
 param skuName string 
 param skuCapacity int
 
-resource dts 'Microsoft.DurableTask/schedulers@2024-10-01-preview' = {
+resource dts 'Microsoft.DurableTask/schedulers@2025-11-01' = {
   location: location
   tags: tags
   name: name
@@ -19,7 +19,7 @@ resource dts 'Microsoft.DurableTask/schedulers@2024-10-01-preview' = {
   }
 }
 
-resource taskhub 'Microsoft.DurableTask/schedulers/taskhubs@2024-10-01-preview' = {
+resource taskhub 'Microsoft.DurableTask/schedulers/taskhubs@2025-11-01' = {
   parent: dts
   name: taskhubname
 }

--- a/samples/scenarios/AutoscalingInACA/infra/app/dts.bicep
+++ b/samples/scenarios/AutoscalingInACA/infra/app/dts.bicep
@@ -6,7 +6,7 @@ param taskhubname string
 param skuName string 
 param skuCapacity int
 
-resource dts 'Microsoft.DurableTask/schedulers@2024-10-01-preview' = {
+resource dts 'Microsoft.DurableTask/schedulers@2025-11-01' = {
   location: location
   tags: tags
   name: name
@@ -19,7 +19,7 @@ resource dts 'Microsoft.DurableTask/schedulers@2024-10-01-preview' = {
   }
 }
 
-resource taskhub 'Microsoft.DurableTask/schedulers/taskhubs@2024-10-01-preview' = {
+resource taskhub 'Microsoft.DurableTask/schedulers/taskhubs@2025-11-01' = {
   parent: dts
   name: taskhubname
 }


### PR DESCRIPTION
This pull request updates the Durable Task resource definitions across several Bicep infrastructure files to use the latest API version, ensuring compatibility with new features and improvements. The changes are applied consistently to both scheduler and taskhub resources in multiple sample and quickstart projects.

**API Version Upgrades:**

* Updated `Microsoft.DurableTask/schedulers` resource definitions from version `2024-10-01-preview` to `2025-11-01` in all relevant `dts.bicep` and `dts-Access.bicep` files for the following projects: `HelloCities`, `AiAgentTravelPlanOrchestrator`, `OrderProcessor`, `PdfSummarizer`, and `AutoscalingInACA`. [[1]](diffhunk://#diff-f718b8aa278d9328c0a36b94c8ceb6f51039d0276138b668ead9da061d012bacL9-R9) [[2]](diffhunk://#diff-ff2434b12d2018a8aa8b5acf7bb9290a6c01653776616849779e25c7bb777d5bL6-R6)
* Updated `Microsoft.DurableTask/schedulers/taskhubs` resource definitions from version `2024-10-01-preview` to `2025-11-01` in all corresponding `dts.bicep` files for the same set of projects.

These updates help ensure that infrastructure deployments leverage the most recent capabilities and improvements provided by the Durable Task service.