### PR TITLE
add export job dotnet sample

### DIFF
--- a/samples/durable-task-sdks/dotnet/ExportHistoryWebApp/ExportHistoryWebApp.csproj
+++ b/samples/durable-task-sdks/dotnet/ExportHistoryWebApp/ExportHistoryWebApp.csproj
@@ -1,0 +1,24 @@
+<Project Sdk="Microsoft.NET.Sdk.Web">
+
+  <PropertyGroup>
+    <TargetFramework>net8.0</TargetFramework>
+    <Nullable>enable</Nullable>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <EmitCompilerGeneratedFiles>true</EmitCompilerGeneratedFiles>
+    <CompilerGeneratedFilesOutputPath>$(BaseIntermediateOutputPath)Generated</CompilerGeneratedFilesOutputPath>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Azure.Identity" Version="1.17.1" />
+    <PackageReference Include="Grpc.Net.Client" Version="2.67.0" />
+    <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="8.0.1" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.DurableTask.Client.AzureManaged" Version="1.22.0" />
+    <PackageReference Include="Microsoft.DurableTask.Worker.AzureManaged" Version="1.22.0" />
+    <PackageReference Include="Microsoft.DurableTask.ExportHistory" Version="1.22.0-preview.1" />
+    <PackageReference Include="Microsoft.DurableTask.Generators" Version="1.0.0-preview.1" OutputItemType="Analyzer" />
+  </ItemGroup>
+</Project>
+

--- a/samples/durable-task-sdks/dotnet/ExportHistoryWebApp/ExportHistoryWebApp.http
+++ b/samples/durable-task-sdks/dotnet/ExportHistoryWebApp/ExportHistoryWebApp.http
@@ -1,0 +1,88 @@
+### Variables
+@baseUrl = http://localhost:5009
+@jobId = export-job-12345
+
+### Create a new batch export job
+# @name createBatchExportJob
+POST {{baseUrl}}/export-jobs
+Content-Type: application/json
+
+{
+  "jobId": "{{jobId}}",
+  "mode": "Batch",
+  "completedTimeFrom": "2025-10-01T00:00:00Z",
+  "completedTimeTo": "2025-11-06T23:59:59Z",
+  "container": "export-history",
+  "prefix": "batch-exports/",
+  "maxInstancesPerBatch": 1,
+  "runtimeStatus": []
+}
+
+### Create a new continuous export job
+# @name createContinuousExportJob
+POST {{baseUrl}}/export-jobs
+Content-Type: application/json
+
+{
+    "jobId": "export-job-continuous-123",
+    "mode": "Continuous",
+    "completedTimeFrom": "2025-10-01T00:00:00Z",
+    "container": "export-history",
+    "prefix": "continuous-exports/",
+    "maxInstancesPerBatch": 1000
+}
+
+### Create an export job with default storage (no container specified)
+# @name createExportJobWithDefaultStorage
+POST {{baseUrl}}/export-jobs
+Content-Type: application/json
+{
+    "jobId": "export-job-default-storage",
+    "mode": "Batch",
+    "completedTimeFrom": "2024-01-01T00:00:00Z",
+    "completedTimeTo": "2024-12-31T23:59:59Z",
+    "maxInstancesPerBatch": 100
+}
+
+### Get a specific export job by ID
+# Note: This endpoint can be used to verify the export job was created and check its status
+# The ID in the URL should match the jobId used in create request
+GET {{baseUrl}}/export-jobs/{{jobId}}
+
+### List all export jobs
+GET {{baseUrl}}/export-jobs/list
+
+### List export jobs with filters
+### Filter by status
+GET {{baseUrl}}/export-jobs/list?status=Active
+
+### Filter by job ID prefix
+GET {{baseUrl}}/export-jobs/list?jobIdPrefix=export-job-
+
+### Filter by creation time range
+GET {{baseUrl}}/export-jobs/list?createdFrom=2024-01-01T00:00:00Z&createdTo=2024-12-31T23:59:59Z
+
+### Combined filters
+GET {{baseUrl}}/export-jobs/list?status=Completed&jobIdPrefix=export-job-&pageSize=50
+
+### Delete an export job
+# DELETE {{baseUrl}}/export-jobs/{{jobId}}
+
+# Delete a continuous export job
+DELETE {{baseUrl}}/export-jobs/export-job-continuous-123
+
+### Tips:
+# - Replace the baseUrl variable if your application runs on a different port
+# - The jobId variable can be changed to test different export job instances
+# - Export modes:
+#   - "Batch": Exports all instances within a time range (requires completedTimeTo)
+#   - "Continuous": Continuously exports instances from a start time (completedTimeTo must be null)
+# - Runtime status filters (valid values):
+#   - "Completed": Exports only completed orchestrations
+#   - "Failed": Exports only failed orchestrations
+#   - "Terminated": Exports only terminated orchestrations
+# - Dates are in ISO 8601 format (YYYY-MM-DDThh:mm:ssZ)
+# - You can use the REST Client extension in VS Code to execute these requests
+# - The @name directive allows referencing the response in subsequent requests
+# - Export jobs run asynchronously; use GET to check the status after creation
+

--- a/samples/durable-task-sdks/dotnet/ExportHistoryWebApp/ExportJobController.cs
+++ b/samples/durable-task-sdks/dotnet/ExportHistoryWebApp/ExportJobController.cs
@@ -1,0 +1,202 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.DurableTask;
+using Microsoft.DurableTask.Client;
+using Microsoft.DurableTask.ExportHistory;
+using ExportHistoryWebApp.Models;
+
+namespace ExportHistoryWebApp.Controllers;
+
+/// <summary>
+/// Controller for managing export history jobs through a REST API.
+/// Provides endpoints for creating, reading, listing, and deleting export jobs.
+/// </summary>
+[ApiController]
+[Route("export-jobs")]
+public class ExportJobController : ControllerBase
+{
+    readonly ExportHistoryClient exportHistoryClient;
+    readonly ILogger<ExportJobController> logger;
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="ExportJobController"/> class.
+    /// </summary>
+    /// <param name="exportHistoryClient">Client for managing export history jobs.</param>
+    /// <param name="logger">Logger for recording controller operations.</param>
+    public ExportJobController(
+        ExportHistoryClient exportHistoryClient,
+        ILogger<ExportJobController> logger)
+    {
+        this.exportHistoryClient = exportHistoryClient ?? throw new ArgumentNullException(nameof(exportHistoryClient));
+        this.logger = logger ?? throw new ArgumentNullException(nameof(logger));
+    }
+
+    /// <summary>
+    /// Creates a new export job based on the provided configuration.
+    /// </summary>
+    /// <param name="request">The export job creation request.</param>
+    /// <returns>The created export job description.</returns>
+    [HttpPost]
+    public async Task<ActionResult<ExportJobDescription>> CreateExportJob([FromBody] CreateExportJobRequest request)
+    {
+        if (request == null)
+        {
+            return this.BadRequest("createExportJobRequest cannot be null");
+        }
+
+        try
+        {
+            ExportDestination? destination = null;
+            if (!string.IsNullOrEmpty(request.Container))
+            {
+                destination = new ExportDestination(request.Container)
+                {
+                    Prefix = request.Prefix,
+                };
+            }
+
+            ExportJobCreationOptions creationOptions = new ExportJobCreationOptions(
+                mode: request.Mode,
+                completedTimeFrom: request.CompletedTimeFrom,
+                completedTimeTo: request.CompletedTimeTo,
+                destination: destination,
+                jobId: request.JobId,
+                format: request.Format,
+                runtimeStatus: request.RuntimeStatus,
+                maxInstancesPerBatch: request.MaxInstancesPerBatch);
+
+            ExportHistoryJobClient jobClient = await this.exportHistoryClient.CreateJobAsync(creationOptions);
+            ExportJobDescription description = await jobClient.DescribeAsync();
+
+            this.logger.LogInformation("Created new export job with ID: {JobId}", description.JobId);
+
+            return this.CreatedAtAction(nameof(GetExportJob), new { id = description.JobId }, description);
+        }
+        catch (ArgumentException ex)
+        {
+            this.logger.LogError(ex, "Validation failed while creating export job {JobId}", request.JobId);
+            return this.BadRequest(ex.Message);
+        }
+        catch (Exception ex)
+        {
+            this.logger.LogError(ex, "Error creating export job {JobId}", request.JobId);
+            return this.StatusCode(500, "An error occurred while creating the export job");
+        }
+    }
+
+    /// <summary>
+    /// Retrieves a specific export job by its ID.
+    /// </summary>
+    /// <param name="id">The ID of the export job to retrieve.</param>
+    /// <returns>The export job description if found.</returns>
+    [HttpGet("{id}")]
+    public async Task<ActionResult<ExportJobDescription>> GetExportJob(string id)
+    {
+        try
+        {
+            ExportJobDescription? job = await this.exportHistoryClient.GetJobAsync(id);
+            return this.Ok(job);
+        }
+        catch (ExportJobNotFoundException)
+        {
+            return this.NotFound();
+        }
+        catch (Exception ex)
+        {
+            this.logger.LogError(ex, "Error retrieving export job {JobId}", id);
+            return this.StatusCode(500, "An error occurred while retrieving the export job");
+        }
+    }
+
+    /// <summary>
+    /// Lists all export jobs, optionally filtered by query parameters.
+    /// </summary>
+    /// <param name="status">Optional filter by job status.</param>
+    /// <param name="jobIdPrefix">Optional filter by job ID prefix.</param>
+    /// <param name="createdFrom">Optional filter for jobs created after this time.</param>
+    /// <param name="createdTo">Optional filter for jobs created before this time.</param>
+    /// <param name="pageSize">Optional page size for pagination.</param>
+    /// <param name="continuationToken">Optional continuation token for pagination.</param>
+    /// <returns>A collection of export job descriptions.</returns>
+    [HttpGet("list")]
+    public async Task<ActionResult<IEnumerable<ExportJobDescription>>> ListExportJobs(
+        [FromQuery] ExportJobStatus? status = null,
+        [FromQuery] string? jobIdPrefix = null,
+        [FromQuery] DateTimeOffset? createdFrom = null,
+        [FromQuery] DateTimeOffset? createdTo = null,
+        [FromQuery] int? pageSize = null,
+        [FromQuery] string? continuationToken = null)
+    {
+        this.logger.LogInformation("GET list endpoint called with method: {Method}", this.HttpContext.Request.Method);
+        try
+        {
+            ExportJobQuery? query = null;
+            if (
+                status.HasValue ||
+                !string.IsNullOrEmpty(jobIdPrefix) ||
+                createdFrom.HasValue ||
+                createdTo.HasValue ||
+                pageSize.HasValue ||
+                !string.IsNullOrEmpty(continuationToken)
+            )
+            {
+                query = new ExportJobQuery
+                {
+                    Status = status,
+                    JobIdPrefix = jobIdPrefix,
+                    CreatedFrom = createdFrom,
+                    CreatedTo = createdTo,
+                    PageSize = pageSize,
+                    ContinuationToken = continuationToken,
+                };
+            }
+
+            AsyncPageable<ExportJobDescription> jobs = this.exportHistoryClient.ListJobsAsync(query);
+
+            // Collect all jobs from the async pageable
+            List<ExportJobDescription> jobList = new List<ExportJobDescription>();
+            await foreach (ExportJobDescription job in jobs)
+            {
+                jobList.Add(job);
+            }
+
+            return this.Ok(jobList);
+        }
+        catch (Exception ex)
+        {
+            this.logger.LogError(ex, "Error retrieving export jobs");
+            return this.StatusCode(500, "An error occurred while retrieving export jobs");
+        }
+    }
+
+    /// <summary>
+    /// Deletes an export job by its ID.
+    /// </summary>
+    /// <param name="id">The ID of the export job to delete.</param>
+    /// <returns>No content if successful.</returns>
+    [HttpDelete("{id}")]
+    public async Task<IActionResult> DeleteExportJob(string id)
+    {
+        this.logger.LogInformation("DELETE endpoint called for job ID: {JobId}", id);
+        try
+        {
+            ExportHistoryJobClient jobClient = this.exportHistoryClient.GetJobClient(id);
+            await jobClient.DeleteAsync();
+            this.logger.LogInformation("Successfully deleted export job {JobId}", id);
+            return this.NoContent();
+        }
+        catch (ExportJobNotFoundException)
+        {
+            this.logger.LogWarning("Export job {JobId} not found for deletion", id);
+            return this.NotFound();
+        }
+        catch (Exception ex)
+        {
+            this.logger.LogError(ex, "Error deleting export job {JobId}", id);
+            return this.StatusCode(500, "An error occurred while deleting the export job");
+        }
+    }
+}
+

--- a/samples/durable-task-sdks/dotnet/ExportHistoryWebApp/Models/CreateExportJobRequest.cs
+++ b/samples/durable-task-sdks/dotnet/ExportHistoryWebApp/Models/CreateExportJobRequest.cs
@@ -1,0 +1,60 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using Microsoft.DurableTask.Client;
+using Microsoft.DurableTask.ExportHistory;
+
+namespace ExportHistoryWebApp.Models;
+
+/// <summary>
+/// Represents a request to create a new export job.
+/// </summary>
+public class CreateExportJobRequest
+{
+    /// <summary>
+    /// Gets or sets the unique identifier for the export job. If not provided, a GUID will be generated.
+    /// </summary>
+    public string? JobId { get; set; }
+
+    /// <summary>
+    /// Gets or sets the export mode (Batch or Continuous).
+    /// </summary>
+    public ExportMode Mode { get; set; }
+
+    /// <summary>
+    /// Gets or sets the start time for the export based on completion time (inclusive). Required.
+    /// </summary>
+    public DateTimeOffset CompletedTimeFrom { get; set; }
+
+    /// <summary>
+    /// Gets or sets the end time for the export based on completion time (inclusive). Required for Batch mode, null for Continuous mode.
+    /// </summary>
+    public DateTimeOffset? CompletedTimeTo { get; set; }
+
+    /// <summary>
+    /// Gets or sets the blob container name where exported data will be stored. Optional if default storage is configured.
+    /// </summary>
+    public string? Container { get; set; }
+
+    /// <summary>
+    /// Gets or sets an optional prefix for blob paths.
+    /// </summary>
+    public string? Prefix { get; set; }
+
+    /// <summary>
+    /// Gets or sets the export format settings. Optional, defaults to jsonl-gzip.
+    /// </summary>
+    public ExportFormat? Format { get; set; }
+
+    /// <summary>
+    /// Gets or sets the orchestration runtime statuses to filter by. Optional.
+    /// Valid statuses are: Completed, Failed, Terminated.
+    /// </summary>
+    public List<OrchestrationRuntimeStatus>? RuntimeStatus { get; set; }
+
+    /// <summary>
+    /// Gets or sets the maximum number of instances to fetch per batch. Optional, defaults to 100.
+    /// </summary>
+    public int? MaxInstancesPerBatch { get; set; }
+}
+

--- a/samples/durable-task-sdks/dotnet/ExportHistoryWebApp/Program.cs
+++ b/samples/durable-task-sdks/dotnet/ExportHistoryWebApp/Program.cs
@@ -1,0 +1,55 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using System.Text.Json.Serialization;
+using Microsoft.DurableTask.Client;
+using Microsoft.DurableTask.Client.AzureManaged;
+using Microsoft.DurableTask.ExportHistory;
+using Microsoft.DurableTask.Worker;
+using Microsoft.DurableTask.Worker.AzureManaged;
+
+WebApplicationBuilder builder = WebApplication.CreateBuilder(args);
+
+string connectionString = builder.Configuration.GetValue<string>("DURABLE_TASK_CONNECTION_STRING")
+    ?? throw new InvalidOperationException("Missing required configuration 'DURABLE_TASK_CONNECTION_STRING'");
+
+string storageConnectionString = builder.Configuration.GetValue<string>("EXPORT_HISTORY_STORAGE_CONNECTION_STRING")
+    ?? throw new InvalidOperationException("Missing required configuration 'EXPORT_HISTORY_STORAGE_CONNECTION_STRING'");
+
+string containerName = builder.Configuration.GetValue<string>("EXPORT_HISTORY_CONTAINER_NAME")
+    ?? throw new InvalidOperationException("Missing required configuration 'EXPORT_HISTORY_CONTAINER_NAME'");
+
+builder.Services.AddSingleton<ILogger>(sp => sp.GetRequiredService<ILoggerFactory>().CreateLogger<Program>());
+builder.Services.AddLogging();
+
+// Add Durable Task worker with export history support
+builder.Services.AddDurableTaskWorker(builder =>
+{
+    builder.UseDurableTaskScheduler(connectionString);
+    builder.UseExportHistory();
+});
+
+// Register the client with export history support
+builder.Services.AddDurableTaskClient(clientBuilder =>
+{
+    clientBuilder.UseDurableTaskScheduler(connectionString);
+    clientBuilder.UseExportHistory(options =>
+    {
+        options.ConnectionString = storageConnectionString;
+        options.ContainerName = containerName;
+        options.Prefix = builder.Configuration.GetValue<string>("EXPORT_HISTORY_PREFIX");
+    });
+});
+
+// Configure the HTTP request pipeline
+builder.Services.AddControllers().AddJsonOptions(options =>
+{
+    options.JsonSerializerOptions.Converters.Add(new JsonStringEnumConverter());
+    options.JsonSerializerOptions.DefaultIgnoreCondition = JsonIgnoreCondition.WhenWritingNull;
+});
+
+// The actual listen URL can be configured in environment variables named "ASPNETCORE_URLS" or "ASPNETCORE_URLS_HTTPS"
+WebApplication app = builder.Build();
+app.MapControllers();
+app.Run();
+

--- a/samples/durable-task-sdks/dotnet/ExportHistoryWebApp/Properties/launchSettings.json
+++ b/samples/durable-task-sdks/dotnet/ExportHistoryWebApp/Properties/launchSettings.json
@@ -1,0 +1,26 @@
+{
+  "$schema": "https://json.schemastore.org/launchsettings.json",
+  "iisSettings": {
+    "windowsAuthentication": false,
+    "anonymousAuthentication": true,
+    "iisExpress": {
+      "applicationUrl": "http://localhost:47698",
+      "sslPort": 44372
+    }
+  },
+  "profiles": {
+    "http": {
+      "commandName": "Project",
+      "applicationUrl": "http://localhost:5009",
+      "dotnetRunMessages": true,
+      "environmentVariables": {
+        "ASPNETCORE_ENVIRONMENT": "Development",
+        "DURABLE_TASK_CONNECTION_STRING": "<your-connection-string>",
+        "EXPORT_HISTORY_STORAGE_CONNECTION_STRING": "<your-storage-connection-string>",
+        "EXPORT_HISTORY_CONTAINER_NAME": "export-history",
+        "EXPORT_HISTORY_PREFIX": ""
+      }
+    }
+  }
+}
+

--- a/samples/durable-task-sdks/dotnet/ExportHistoryWebApp/README.md
+++ b/samples/durable-task-sdks/dotnet/ExportHistoryWebApp/README.md
@@ -1,0 +1,115 @@
+# Export History Web App Sample
+
+This sample is a small ASP.NET Core web app that exposes a REST API for creating and managing Durable Task **export history jobs**.
+
+It uses:
+
+- **Durable Task Scheduler (Azure Managed)** for listing instance history
+- **Azure Blob Storage** as the export destination for exported orchestration history
+
+## Prerequisites
+
+- A Durable Task Scheduler hub connection string
+- An Azure Storage account connection string (or Azurite/Storage Emulator)
+
+## Configure
+
+The app reads configuration from standard .NET configuration sources (environment variables, `appsettings*.json`, command-line, etc.).
+
+Required settings:
+
+- `DURABLE_TASK_CONNECTION_STRING`
+  - Durable Task Scheduler connection string for your task hub.
+- `EXPORT_HISTORY_STORAGE_CONNECTION_STRING`
+  - Azure Storage connection string used for writing exported history.
+- `EXPORT_HISTORY_CONTAINER_NAME`
+  - Default blob container name for export output.
+
+Optional settings:
+
+- `EXPORT_HISTORY_PREFIX`
+  - Default blob “folder” prefix used when writing blobs.
+
+## Run
+
+From the repo root:
+
+```bash
+dotnet run --project samples/durable-task-sdks/dotnet/ExportHistoryWebApp/ExportHistoryWebApp.csproj
+```
+
+The default `launchSettings.json` profile listens on:
+
+- `http://localhost:5009`
+
+## Interact with the export API
+
+The controller is rooted at `export-jobs` and supports create/get/list/delete.
+
+### Create an export job
+
+`POST /export-jobs`
+
+Request body (see `Models/CreateExportJobRequest.cs`):
+
+- `jobId` (optional): If omitted, a GUID is generated.
+- `mode`: `Batch` or `Continuous`.
+- `completedTimeFrom`: Start of the export time window (inclusive).
+- `completedTimeTo`:
+  - Required for `Batch`
+  - Must be omitted/null for `Continuous`
+- `container` / `prefix` (optional): Overrides the default destination configured in app settings.
+- `runtimeStatus` (optional): Filters exported instances by terminal status.
+  - Allowed values: `Completed`, `Failed`, `Terminated`
+- `maxInstancesPerBatch` (optional): 1–1000 (defaults to 100).
+- `format` (optional): Defaults to JSONL + gzip.
+
+Notes:
+- For `Batch` mode, `completedTimeTo` must be greater than `completedTimeFrom` and cannot be in the future.
+
+### Get a job
+
+`GET /export-jobs/{id}`
+
+Returns an `ExportJobDescription` if the job exists.
+
+### List jobs
+
+`GET /export-jobs/list`
+
+Optional query parameters:
+
+- `status`: `Pending`, `Active`, `Failed`, `Completed`
+- `jobIdPrefix`
+- `createdFrom`, `createdTo`
+- `pageSize`, `continuationToken`
+
+### Delete a job
+
+`DELETE /export-jobs/{id}`
+
+## Where exported data goes
+
+Exported history is written to Azure Blob Storage:
+
+- Container: default from `EXPORT_HISTORY_CONTAINER_NAME` (or per-request `container` override)
+- Blob name: derived from a SHA-256 hash of `(completedTimestamp, instanceId)`
+- File extension:
+  - Default: `.jsonl.gz` (JSON Lines, gzip-compressed)
+  - Optional: `.json` (if configured via `format`)
+
+If a prefix is configured, the blob path becomes:
+
+- `{prefix}/{hash}.{ext}`
+
+## Using the included HTTP file
+
+This sample includes ready-made requests in `ExportHistoryWebApp.http`.
+
+In VS Code:
+
+1. Install the “REST Client” extension (if you don’t already have it).
+2. Open `ExportHistoryWebApp.http`.
+3. Click “Send Request” on any request block.
+
+Adjust the `@baseUrl` variable if you run the app on a different port.

--- a/samples/durable-task-sdks/dotnet/ExportHistoryWebApp/appsettings.Development.json
+++ b/samples/durable-task-sdks/dotnet/ExportHistoryWebApp/appsettings.Development.json
@@ -1,0 +1,9 @@
+{
+  "Logging": {
+    "LogLevel": {
+      "Default": "Information",
+      "Microsoft.AspNetCore": "Warning"
+    }
+  }
+}
+

--- a/samples/durable-task-sdks/dotnet/ExportHistoryWebApp/appsettings.json
+++ b/samples/durable-task-sdks/dotnet/ExportHistoryWebApp/appsettings.json
@@ -1,0 +1,10 @@
+{
+  "Logging": {
+    "LogLevel": {
+      "Default": "Information",
+      "Microsoft.AspNetCore": "Warning"
+    }
+  },
+  "AllowedHosts": "*"
+}
+


### PR DESCRIPTION
Add the Export History Web App sample for the .NET Durable Task SDK. This is an ASP.NET Core web app that exposes a REST API for creating and managing Durable Task export history jobs, using Durable Task Scheduler (Azure Managed) and Azure Blob Storage.

Does this introduce a breaking change?


 No
Pull Request Type

sample

Please describe:
How to Test

Get the code:

Test the code:

Set the required environment variables (or update [launchSettings.json](vscode-file://vscode-app/d:/Microsoft%20VS%20Code/b6a47e94e3/resources/app/out/vs/code/electron-browser/workbench/workbench.html)):
DURABLE_TASK_CONNECTION_STRING — Durable Task Scheduler connection string
EXPORT_HISTORY_STORAGE_CONNECTION_STRING — Azure Storage connection string
EXPORT_HISTORY_CONTAINER_NAME — Blob container name (e.g. export-history)
Run the sample:
Use the included [ExportHistoryWebApp.http](vscode-file://vscode-app/d:/Microsoft%20VS%20Code/b6a47e94e3/resources/app/out/vs/code/electron-browser/workbench/workbench.html) file (with the VS Code REST Client extension) or curl to interact with the API at http://localhost:5009.
What to Check

Verify that the following are valid:

 The project restores and builds successfully with dotnet build
 The app starts and listens on http://localhost:5009
 [POST /export-jobs](vscode-file://vscode-app/d:/Microsoft%20VS%20Code/b6a47e94e3/resources/app/out/vs/code/electron-browser/workbench/workbench.html) creates a new batch or continuous export job
 [GET /export-jobs/{id}](vscode-file://vscode-app/d:/Microsoft%20VS%20Code/b6a47e94e3/resources/app/out/vs/code/electron-browser/workbench/workbench.html) retrieves an export job by ID
 GET /export-jobs/list lists all export jobs (with optional query filters)
 [DELETE /export-jobs/{id}](vscode-file://vscode-app/d:/Microsoft%20VS%20Code/b6a47e94e3/resources/app/out/vs/code/electron-browser/workbench/workbench.html) deletes an export job
 The README accurately describes the sample, configuration, and API endpoints
 The sample follows the same structure and conventions as other .NET samples in [dotnet](vscode-file://vscode-app/d:/Microsoft%20VS%20Code/b6a47e94e3/resources/app/out/vs/code/electron-browser/workbench/workbench.html)
Note: This sample depends on the [Microsoft.DurableTask.ExportHistory](vscode-file://vscode-app/d:/Microsoft%20VS%20Code/b6a47e94e3/resources/app/out/vs/code/electron-browser/workbench/workbench.html) NuGet package, which is pending publication (see [microsoft/durabletask-dotnet PR](vscode-file://vscode-app/d:/Microsoft%20VS%20Code/b6a47e94e3/resources/app/out/vs/code/electron-browser/workbench/workbench.html)). 


Testing:

Local running all operations in sample pass against a dts scheduler with single taskhub.
