### PR TITLE
Auto-merge grouped Dependabot updates once build-samples passes

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -11,6 +11,10 @@ updates:
       - "/samples/scenarios/**"
     schedule:
       interval: "monthly"
+    groups:
+      nuget-all:
+        patterns: ["*"]
+        update-types: ["patch", "minor", "major"]
 
   # Java (Maven)
   - package-ecosystem: "maven"
@@ -18,6 +22,10 @@ updates:
       - "/samples/durable-functions/java/**"
     schedule:
       interval: "monthly"
+    groups:
+      maven-all:
+        patterns: ["*"]
+        update-types: ["patch", "minor", "major"]
 
   # Java (Gradle)
   - package-ecosystem: "gradle"
@@ -25,6 +33,10 @@ updates:
       - "/samples/durable-task-sdks/java/**"
     schedule:
       interval: "monthly"
+    groups:
+      gradle-all:
+        patterns: ["*"]
+        update-types: ["patch", "minor", "major"]
 
   # Python (pip)
   - package-ecosystem: "pip"
@@ -33,6 +45,10 @@ updates:
       - "/samples/durable-functions/python/**"
     schedule:
       interval: "monthly"
+    groups:
+      pip-all:
+        patterns: ["*"]
+        update-types: ["patch", "minor", "major"]
 
   # JavaScript (npm)
   - package-ecosystem: "npm"
@@ -41,12 +57,20 @@ updates:
       - "/samples/durable-functions/dotnet/AiAgentTravelPlanOrchestrator/Frontend"
     schedule:
       interval: "monthly"
+    groups:
+      npm-all:
+        patterns: ["*"]
+        update-types: ["patch", "minor", "major"]
 
   # GitHub Actions
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:
       interval: "monthly"
+    groups:
+      github-actions-all:
+        patterns: ["*"]
+        update-types: ["patch", "minor", "major"]
 
   # Docker
   - package-ecosystem: "docker"
@@ -57,3 +81,7 @@ updates:
       - "/samples/durable-task-sdks/dotnet/FunctionChaining/**"
     schedule:
       interval: "monthly"
+    groups:
+      docker-all:
+        patterns: ["*"]
+        update-types: ["patch", "minor", "major"]

--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -1,0 +1,31 @@
+name: Dependabot auto-merge
+
+on:
+  pull_request:
+    types: [opened, reopened, synchronize]
+
+# IMPORTANT: For auto-merge to actually wait for CI before merging,
+# the build-samples.yml jobs (dotnet, java, python, javascript, typescript)
+# must be configured as REQUIRED status checks on the `main` branch.
+# Configure under repo Settings -> Branches -> branch protection rule for `main`.
+# Without this, auto-merge will merge the PR immediately with no CI gate.
+
+permissions:
+  pull-requests: write
+
+jobs:
+  auto-merge:
+    runs-on: ubuntu-latest
+    if: github.actor == 'dependabot[bot]'
+    steps:
+      - name: Fetch Dependabot metadata
+        id: metadata
+        uses: dependabot/fetch-metadata@v2
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Enable auto-merge
+        run: gh pr merge --auto --squash "$PR_URL"
+        env:
+          PR_URL: ${{ github.event.pull_request.html_url }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Summary

Adds automation so Dependabot updates merge themselves once the existing `build-samples.yml` CI passes, with all updates per ecosystem bundled into a single PR.

Implements the [GitHub-recommended Dependabot auto-merge pattern](https://docs.github.com/en/code-security/tutorials/secure-your-dependencies/automating-dependabot-with-github-actions#enabling-automerge-on-a-pull-request).

## Changes

- **`.github/dependabot.yml`** — added a `groups: <ecosystem>-all` block (patterns `["*"]`, all update-types) to all 7 ecosystem entries (`nuget`, `maven`, `gradle`, `pip`, `npm`, `github-actions`, `docker`). Dependabot will now open one PR per ecosystem per scheduled run instead of one PR per dependency.
- **`.github/workflows/dependabot-auto-merge.yml`** (new) — event-driven workflow that fires on `pull_request` from `dependabot[bot]`, calls `dependabot/fetch-metadata@v2`, then `gh pr merge --auto --squash` to enable GitHub's native auto-merge. Permissions: `pull-requests: write` only.
- **`docs/superpowers/specs/2026-05-01-dependabot-auto-merge-design.md`** — design spec.
- **`docs/superpowers/plans/2026-05-01-dependabot-auto-merge.md`** — implementation plan.

## How the merge gate works

GitHub's native auto-merge waits for **required status checks** on `main` before merging. The repo's existing `build-samples.yml` builds every sample (.NET, Java, Python, JS, TS) and runs on every PR touching `samples/**`.

## ⚠️ Required follow-up (manual, in repo Settings)

For auto-merge to actually wait for CI, the following must be configured **before** this PR merges (otherwise Dependabot PRs would auto-merge instantly with no CI gate):

1. **Settings → General → Pull Requests → "Allow auto-merge"** — must be enabled.
2. **Settings → Branches → Branch protection rule for `main` → Require status checks to pass before merging** — add the `build-samples.yml` job names as required checks: `dotnet`, `java`, `python`, `javascript`, `typescript`.

The workflow file's top comment also calls this out.

## Risks (documented in the spec)

- **Path-filtered CI** — `build-samples.yml` only triggers on `samples/**` paths. Dependabot PRs in the `github-actions` ecosystem (and some `docker` PRs) won't trigger it, so they'd auto-merge with no CI. Acceptable for these low-risk version-only bumps; can be tightened later by broadening the path filter or adding a workflow-lint check.
- **Grouped major bumps** — A bad bump in a group blocks all good bumps in that group; standard grouping trade-off, can be unblocked by editing the PR or temporarily ignoring the bad dep.

## Out of scope

- No changes to `build-samples.yml` (path filter intentional).
- No filtering by update-type (per design — auto-merge all types; CI is the gate).
- No daily cron (the workflow is event-driven, which is strictly better than daily).