### PR TITLE
Fix: restore contents: write to dependabot-auto-merge workflow

### DIFF
--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -11,6 +11,7 @@ on:
 # Without this, auto-merge will merge the PR immediately with no CI gate.
 
 permissions:
+  contents: write
   pull-requests: write
 
 jobs:


### PR DESCRIPTION
## Problem

The auto-merge workflow shipped in #281 fails on every Dependabot PR with:

```
GraphQL: Resource not accessible by integration (mergePullRequest)
Error: Process completed with exit code 1.
```

Observed on [PR #283](https://github.com/Azure-Samples/Durable-Task-Scheduler/pull/283) (Dependabot maven-all group).

## Root cause

`gh pr merge --auto` calls GitHub's GraphQL `enablePullRequestAutoMerge` mutation (or `mergePullRequest` if no merge conditions exist to wait for). Both mutations require **`contents: write`** on the `GITHUB_TOKEN`. The shipped workflow only had `pull-requests: write`, which is insufficient.

GitHub's [canonical auto-merge example](https://docs.github.com/en/code-security/tutorials/secure-your-dependencies/automating-dependabot-with-github-actions#enabling-automerge-on-a-pull-request) explicitly uses both — that was right; tightening was wrong.

## Fix

Restore `contents: write` to the workflow's `permissions:` block.

```diff
 permissions:
+  contents: write
   pull-requests: write
```

## ⚠️ Separate but urgent: branch protection on `main`

`main` currently has **no branch protection** and no required status checks. Once this fix merges, `gh pr merge --auto` will succeed — and because there are no required checks to wait for, **every Dependabot PR will merge instantly with no CI gate**. This is the risk explicitly documented in the design spec.

**Action required before this fix is consumed at scale:**

Settings → Branches → Add branch protection rule for `main`:
- ✅ Require status checks to pass before merging
- ✅ Add required checks: `dotnet`, `java`, `python`, `javascript`, `typescript` (the job names from `build-samples.yml`)
- ✅ Require branches to be up to date before merging (recommended)

Without this, the auto-merge automation has no validation gate for Dependabot PRs that touch `samples/**`.

## Re-running on PR #283

Once this is merged, close + reopen #283 (or push an empty commit) to retrigger the workflow with the corrected permissions.
