### PR TITLE
Fix LargePayload sample build: rename ExternalizeThresholdBytes to ThresholdBytes

### DIFF
--- a/samples/durable-task-sdks/dotnet/LargePayload/Program.cs
+++ b/samples/durable-task-sdks/dotnet/LargePayload/Program.cs
@@ -53,7 +53,7 @@ builder.Services.AddLogging(logging =>
 
 builder.Services.AddExternalizedPayloadStore(options =>
 {
-    options.ExternalizeThresholdBytes = externalizeThresholdBytes;
+    options.ThresholdBytes = externalizeThresholdBytes;
     options.ContainerName = payloadStorageSettings.ContainerName;
 
     if (!string.IsNullOrWhiteSpace(payloadStorageSettings.ConnectionString))


### PR DESCRIPTION
## Why
`Build DTS - LargePayload` is currently failing on `main` and on every open PR (e.g. [PR #307 run](https://github.com/Azure-Samples/Durable-Task-Scheduler/actions/runs/25772169288/job/75697411999?pr=307)) with:

```
error CS1061: 'LargePayloadStorageOptions' does not contain a definition for 'ExternalizeThresholdBytes'
```

In `Microsoft.DurableTask.Extensions.AzureBlobPayloads`, `LargePayloadStorageOptions.ExternalizeThresholdBytes` was renamed to `ThresholdBytes` starting in v1.23.3.

Dependabot's nuget-all group bump (PR #287) raised the sample's reference from 1.21.0 → 1.24.1 on main, but did not update the source to use the new property name. This PR fills that gap.

## What
- `samples/durable-task-sdks/dotnet/LargePayload/Program.cs`: rename the single SDK option assignment from `ExternalizeThresholdBytes` to `ThresholdBytes`.

No `.csproj` change — package versions on main already expose the new API.

## Verification
```
$ dotnet build samples/durable-task-sdks/dotnet/LargePayload/LargePayload.csproj
Build succeeded.
    0 Warning(s)
    0 Error(s)
```

Once this lands on `main`, the existing Dependabot PRs (including #307) will be unblocked on the next CI run.