### PR TITLE
Add Durable Functions critical sections samples (JavaScript + TypeScript)

### DIFF
--- a/samples/durable-functions/javascript/CriticalSections/.gitignore
+++ b/samples/durable-functions/javascript/CriticalSections/.gitignore
@@ -1,0 +1,3 @@
+bin/
+obj/
+node_modules/

--- a/samples/durable-functions/javascript/CriticalSections/NuGet.Config
+++ b/samples/durable-functions/javascript/CriticalSections/NuGet.Config
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="utf-8"?>
+<configuration>
+  <packageSources>
+    <clear />
+    <!-- Restore the Durable extension packages from nuget.org only. -->
+    <add key="nuget.org" value="https://api.nuget.org/v3/index.json" />
+  </packageSources>
+</configuration>

--- a/samples/durable-functions/javascript/CriticalSections/README.md
+++ b/samples/durable-functions/javascript/CriticalSections/README.md
@@ -27,10 +27,10 @@ try {
 
 ### Release patterns demonstrated
 
-| Pattern | Boilerplate | Exception-safe? | Hold time | Min Node | File |
-|---------|-------------|-----------------|-----------|----------|------|
+| Pattern | Boilerplate | Lock released on error? | Hold time | Min Node | File |
+|---------|-------------|-------------------------|-----------|----------|------|
 | `using` | None | ✅ Automatic | Block scope | 24+ | [usingPattern.js](src/functions/usingPattern.js) |
-| `try / finally` | 3 lines | ✅ If written correctly | Block scope | 18+ | [criticalSections.js](src/functions/criticalSections.js) |
+| `try / finally` | 3 lines | ✅ If `release()` is in `finally` | Block scope | 18+ | [criticalSections.js](src/functions/criticalSections.js) |
 | Implicit (no release) | None | ✅ Always | **Entire orchestration** | 18+ | [criticalSections.js](src/functions/criticalSections.js) |
 | `try / finally` + early `release()` | 4 lines | ✅ + minimal hold time | Until first release | 18+ | [criticalSections.js](src/functions/criticalSections.js) |
 

--- a/samples/durable-functions/javascript/CriticalSections/README.md
+++ b/samples/durable-functions/javascript/CriticalSections/README.md
@@ -1,0 +1,148 @@
+# Critical Sections — Durable Functions JavaScript
+
+JavaScript | Durable Functions | Durable Task Scheduler
+
+## Description
+
+This sample demonstrates **critical sections** — the ability to lock one or more
+[durable entities](https://learn.microsoft.com/azure/azure-functions/durable/durable-functions-entities)
+so that only one orchestration at a time can operate on them. Locks make
+multi-entity operations (like transferring money between two accounts) safe and
+atomic.
+
+The lock API was added in **durable-functions 3.4.0** and requires the
+**Microsoft.Azure.WebJobs.Extensions.DurableTask 3.13.0** extension. Acquire a
+lock with `context.df.lock(...)`, which returns a `DurableLock` you can release
+explicitly, dispose automatically, or let the extension free for you.
+
+```js
+const lock = yield context.df.lock(src, dst);
+try {
+  yield context.df.callEntity(src, "add", -amount);
+  yield context.df.callEntity(dst, "add", amount);
+} finally {
+  lock.release();
+}
+```
+
+### Release patterns demonstrated
+
+| Pattern | Boilerplate | Exception-safe? | Hold time | Min Node | File |
+|---------|-------------|-----------------|-----------|----------|------|
+| `using` | None | ✅ Automatic | Block scope | 24+ | [usingPattern.js](src/functions/usingPattern.js) |
+| `try / finally` | 3 lines | ✅ If written correctly | Block scope | 18+ | [criticalSections.js](src/functions/criticalSections.js) |
+| Implicit (no release) | None | ✅ Always | **Entire orchestration** | 18+ | [criticalSections.js](src/functions/criticalSections.js) |
+| `try / finally` + early `release()` | 4 lines | ✅ + minimal hold time | Until first release | 18+ | [criticalSections.js](src/functions/criticalSections.js) |
+
+> **The `using` pattern needs Node.js 24+.** It uses the native `using`
+> declaration (ECMAScript Explicit Resource Management), which only parses on
+> Node.js 24+. It is isolated in [usingPattern.js](src/functions/usingPattern.js)
+> so the other three patterns still load on Node.js 18–22. **If you are on
+> Node.js 18–22, delete `src/functions/usingPattern.js` before running.**
+> (TypeScript users can use `using` on Node.js 18+ — see the TypeScript sample,
+> where TypeScript compiles `using` down for older runtimes.)
+
+## Prerequisites
+
+1. [Node.js 18+](https://nodejs.org/) (Node.js 24+ to run the `using` pattern)
+2. [Azure Functions Core Tools v4](https://learn.microsoft.com/azure/azure-functions/functions-run-local) (4.0.5382 or higher)
+3. [.NET SDK 8.0+](https://dotnet.microsoft.com/download) (to build/install the extension)
+4. [Docker](https://www.docker.com/products/docker-desktop/) (for the Durable Task Scheduler emulator)
+
+## Install the Durable extension manually
+
+The 3.13.0 extension that powers critical sections is **not yet in the Azure
+Functions extension bundles**, so this sample does **not** use a bundle. Instead,
+it ships an [extensions.csproj](extensions.csproj) that references the required
+packages, and you build it once to generate `bin/extensions.json`:
+
+```bash
+cd samples/durable-functions/javascript/CriticalSections
+dotnet build extensions.csproj -o bin
+```
+
+This restores from nuget.org and writes the extension assemblies plus
+`extensions.json` into `bin/`, where the Functions host loads them. You only need
+to run this once (or whenever you change [extensions.csproj](extensions.csproj)).
+
+> **Why no `extensionBundle` in host.json?** Extension bundles pin a fixed set of
+> extension versions. Because 3.13.0 isn't in a published bundle yet at the time of publishing this sample,
+> we remove the `extensionBundle` section and install the extension explicitly. Once a
+> bundle ships with 3.13.0+, you can switch back to a bundle and delete
+> `extensions.csproj`, `NuGet.Config`, and the `bin/`/`obj/` folders. Check the
+> [Extension Bundles Release](https://github.com/Azure/azure-functions-extension-bundles/releases)
+> page to check if 3.13.0 is published.
+
+The extension packages installed (see [extensions.csproj](extensions.csproj)):
+
+| Package | Version | Purpose |
+|---------|---------|---------|
+| `Microsoft.Azure.WebJobs.Extensions.DurableTask` | 3.13.0 | Durable extension with critical-section (lock) support |
+| `Microsoft.Azure.WebJobs.Extensions.DurableTask.AzureManaged` | 1.9.0 | Durable Task Scheduler (azureManaged) backend |
+| `Microsoft.Azure.WebJobs.Script.ExtensionsMetadataGenerator` | 4.0.1 | Generates `bin/extensions.json` |
+
+## Run the sample
+
+1. Start the Durable Task Scheduler emulator:
+
+   ```bash
+   docker run -d -p 8080:8080 -p 8082:8082 mcr.microsoft.com/dts/dts-emulator:latest
+   ```
+
+2. Install the extension (once) and the npm dependencies, then start the host:
+
+   ```bash
+   dotnet build extensions.csproj -o bin
+   npm install
+   func start
+   ```
+
+3. Start a transfer with one of the release patterns:
+
+   ```bash
+   curl -X POST http://localhost:7071/api/transfer/try-finally
+   curl -X POST http://localhost:7071/api/transfer/implicit
+   curl -X POST http://localhost:7071/api/transfer/early-release
+   curl -X POST http://localhost:7071/api/transfer/using      # Node.js 24+ only
+   ```
+
+   Optional query parameters: `?from=alice&to=bob&amount=30` (defaults shown).
+
+4. Follow the `statusQueryGetUri` returned by the call to see the orchestration
+   output, or read an account balance directly:
+
+   ```bash
+   curl "http://localhost:7071/api/balance?key=alice"
+   curl "http://localhost:7071/api/balance?key=bob"
+   ```
+
+5. View instances in the dashboard: http://localhost:8082
+
+## Expected output
+
+Each transfer seeds `alice = 100` and `bob = 0`, then moves `amount` from `alice`
+to `bob` inside a critical section. The orchestration output shows the lock state
+and the resulting balances, for example (`try-finally`):
+
+```json
+{
+  "pattern": "try/finally",
+  "lockedInside": true,
+  "lockedAfter": false,
+  "balances": { "alice": 70, "bob": 30 }
+}
+```
+
+- `lockedInside` is `true` while the critical section is active.
+- `lockedAfter` is `false` once the lock is released — **except** for the
+  `implicit` pattern, where it stays `true` because the extension only frees the
+  lock when the orchestration ends.
+- The `early-release` result additionally includes `lockedAfterEarlyRelease`
+  (`false`) and a `receipt`, showing that non-critical work ran after the lock
+  was freed.
+
+## Learn more
+
+- [Durable entities](https://learn.microsoft.com/azure/azure-functions/durable/durable-functions-entities)
+- [Durable Functions JavaScript API reference](https://learn.microsoft.com/javascript/api/durable-functions/)
+- [Durable Task Scheduler documentation](https://aka.ms/dts-documentation)

--- a/samples/durable-functions/javascript/CriticalSections/extensions.csproj
+++ b/samples/durable-functions/javascript/CriticalSections/extensions.csproj
@@ -1,0 +1,15 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net8.0</TargetFramework>
+    <!-- Keep the function app payload (node_modules, src) when building into bin/. -->
+    <_FunctionsSkipCleanOutput>true</_FunctionsSkipCleanOutput>
+  </PropertyGroup>
+  <ItemGroup>
+    <!-- Generates bin/extensions.json so the host loads the manually installed extensions (no extension bundle). -->
+    <PackageReference Include="Microsoft.Azure.WebJobs.Script.ExtensionsMetadataGenerator" Version="4.0.1" />
+    <!-- Released Durable extension that supports the OOProc schema V4 required by critical sections / lock. -->
+    <PackageReference Include="Microsoft.Azure.WebJobs.Extensions.DurableTask" Version="3.13.0" />
+    <!-- Durable Task Scheduler (azureManaged) backend provider. -->
+    <PackageReference Include="Microsoft.Azure.WebJobs.Extensions.DurableTask.AzureManaged" Version="1.9.0" />
+  </ItemGroup>
+</Project>

--- a/samples/durable-functions/javascript/CriticalSections/host.json
+++ b/samples/durable-functions/javascript/CriticalSections/host.json
@@ -1,0 +1,17 @@
+{
+  "version": "2.0",
+  "logging": {
+    "logLevel": {
+      "DurableTask.Core": "Warning"
+    }
+  },
+  "extensions": {
+    "durableTask": {
+      "hubName": "default",
+      "storageProvider": {
+        "type": "azureManaged",
+        "connectionStringName": "DURABLE_TASK_SCHEDULER_CONNECTION_STRING"
+      }
+    }
+  }
+}

--- a/samples/durable-functions/javascript/CriticalSections/package.json
+++ b/samples/durable-functions/javascript/CriticalSections/package.json
@@ -1,0 +1,13 @@
+{
+  "name": "durable-functions-critical-sections-js",
+  "version": "1.0.0",
+  "description": "Durable Functions JavaScript sample: entity critical sections (locks) with the Durable Task Scheduler backend",
+  "main": "src/functions/*.js",
+  "scripts": {
+    "start": "func start"
+  },
+  "dependencies": {
+    "@azure/functions": "^4.0.0",
+    "durable-functions": "^3.4.0"
+  }
+}

--- a/samples/durable-functions/javascript/CriticalSections/src/functions/criticalSections.js
+++ b/samples/durable-functions/javascript/CriticalSections/src/functions/criticalSections.js
@@ -1,0 +1,226 @@
+const { app } = require("@azure/functions");
+const df = require("durable-functions");
+
+// ============================================================================
+// Critical sections (entity locks) — JavaScript sample.
+//
+// Feature: context.df.lock(...) acquires a critical section over one or more
+// entities so that only one orchestration at a time can operate on them. This
+// is the building block for safe, atomic multi-entity operations such as a
+// money transfer between two accounts.
+//
+//   - SDK:        durable-functions 3.4.0+
+//   - Extension:  Microsoft.Azure.WebJobs.Extensions.DurableTask 3.13.0+
+//                 (installed manually — see README; not in extension bundles yet)
+//   - Backend:    Durable Task Scheduler (azureManaged)
+//
+// This file demonstrates three lock-release patterns that work on Node.js 18+:
+//   2. try / finally               -> explicit release in a finally block
+//   3. Implicit                    -> no release; extension frees it at orch end
+//   4. try / finally + early release -> release early, then do non-critical work
+//
+// The fourth pattern, `using` (zero-boilerplate auto-release), requires
+// Node.js 24+ and lives in ./usingPattern.js.
+// ============================================================================
+
+// ----------------------------------------------------------------------------
+// Account entity — stores a numeric balance and supports set / add / get.
+// ----------------------------------------------------------------------------
+df.app.entity("account", function (context) {
+  let balance = context.df.getState(() => 0);
+  switch (context.df.operationName) {
+    case "set":
+      balance = context.df.getInput();
+      break;
+    case "add":
+      balance += context.df.getInput();
+      break;
+    case "get":
+      context.df.return(balance);
+      break;
+  }
+  context.df.setState(balance);
+});
+
+// ----------------------------------------------------------------------------
+// Activity used by the early-release pattern to do work AFTER the lock is freed.
+// ----------------------------------------------------------------------------
+df.app.activity("sendReceipt", {
+  handler: (input) => `receipt:${input.fromKey}->${input.toKey}:${input.amount}`,
+});
+
+// ============================================================================
+// Pattern 2 — try / finally (explicit release in finally; Node 18+)
+//
+// The lock is held for the whole try block and released in finally, so it is
+// freed even if the body throws. This is the universal pattern: it works on
+// any Node.js/TypeScript version.
+// ============================================================================
+df.app.orchestration("transferTryFinally", function* (context) {
+  const { fromKey, toKey, amount } = context.df.getInput();
+  const src = new df.EntityId("account", fromKey);
+  const dst = new df.EntityId("account", toKey);
+
+  // Seed known starting balances so the sample is self-contained (outside the lock).
+  yield context.df.callEntity(src, "set", 100);
+  yield context.df.callEntity(dst, "set", 0);
+
+  const lock = yield context.df.lock(src, dst);
+  const { isLocked: lockedInside } = context.df.isLocked(); // true — the lock is held
+  try {
+    yield context.df.callEntity(src, "add", -amount);
+    yield context.df.callEntity(dst, "add", amount);
+  } finally {
+    lock.release();
+  }
+
+  const { isLocked: lockedAfter } = context.df.isLocked(); // released -> false
+  return yield* summarize(context, "try/finally", src, dst, fromKey, toKey, {
+    lockedInside,
+    lockedAfter,
+  });
+});
+
+// ============================================================================
+// Pattern 3 — Implicit (no release; extension frees the lock at orch end; Node 18+)
+//
+// No release() call. The lock is held until the orchestration terminates, at
+// which point the extension releases it automatically. Always exception-safe,
+// but the lock is held for the entire orchestration — the longest hold time.
+// ============================================================================
+df.app.orchestration("transferImplicit", function* (context) {
+  const { fromKey, toKey, amount } = context.df.getInput();
+  const src = new df.EntityId("account", fromKey);
+  const dst = new df.EntityId("account", toKey);
+
+  yield context.df.callEntity(src, "set", 100);
+  yield context.df.callEntity(dst, "set", 0);
+
+  yield context.df.lock(src, dst);
+  const { isLocked: lockedInside } = context.df.isLocked(); // true
+  yield context.df.callEntity(src, "add", -amount);
+  yield context.df.callEntity(dst, "add", amount);
+  // No release(). lockedAfter stays true here; the extension frees the lock
+  // when the orchestration completes.
+
+  const { isLocked: lockedAfter } = context.df.isLocked(); // still true
+  return yield* summarize(context, "implicit", src, dst, fromKey, toKey, {
+    lockedInside,
+    lockedAfter,
+  });
+});
+
+// ============================================================================
+// Pattern 4 — try / finally + early release (Node 18+)
+//
+// Release the lock as soon as the critical work is done, then continue with
+// non-critical work (here, sending a receipt) while OTHER orchestrations are
+// free to acquire the lock. The finally block's release() is an idempotent
+// safety net in case the body throws before the early release runs.
+// ============================================================================
+df.app.orchestration("transferEarlyRelease", function* (context) {
+  const { fromKey, toKey, amount } = context.df.getInput();
+  const src = new df.EntityId("account", fromKey);
+  const dst = new df.EntityId("account", toKey);
+
+  yield context.df.callEntity(src, "set", 100);
+  yield context.df.callEntity(dst, "set", 0);
+
+  const lock = yield context.df.lock(src, dst);
+  const { isLocked: lockedInside } = context.df.isLocked(); // true — the lock is held
+  try {
+    yield context.df.callEntity(src, "add", -amount);
+    yield context.df.callEntity(dst, "add", amount);
+
+    lock.release(); // release early — other orchestrations can now proceed
+    const { isLocked: lockedAfterEarlyRelease } = context.df.isLocked(); // false
+
+    // Non-critical work done AFTER the lock is freed.
+    const receipt = yield context.df.callActivity("sendReceipt", { fromKey, toKey, amount });
+
+    const { isLocked: lockedAfter } = context.df.isLocked(); // false
+    return yield* summarize(context, "try/finally+early", src, dst, fromKey, toKey, {
+      lockedInside,
+      lockedAfterEarlyRelease,
+      receipt,
+      lockedAfter,
+    });
+  } finally {
+    lock.release(); // idempotent safety net; no-op if already released
+  }
+});
+
+// ----------------------------------------------------------------------------
+// Helper: read the final balances (unlocked get calls) and build the result.
+// Implemented as a generator so it can `yield` durable calls from the caller.
+// ----------------------------------------------------------------------------
+function* summarize(context, pattern, src, dst, fromKey, toKey, extra) {
+  const fromBalance = yield context.df.callEntity(src, "get");
+  const toBalance = yield context.df.callEntity(dst, "get");
+  return {
+    pattern,
+    ...extra,
+    balances: { [fromKey]: fromBalance, [toKey]: toBalance },
+  };
+}
+
+// Map the {pattern} route value to the orchestration name. The `using`
+// orchestration (transferUsing) is registered in ./usingPattern.js, which is
+// loaded alongside this file on Node.js 24+.
+const PATTERN_TO_ORCH = {
+  using: "transferUsing",
+  "try-finally": "transferTryFinally",
+  implicit: "transferImplicit",
+  "early-release": "transferEarlyRelease",
+};
+
+// ============================================================================
+// HTTP trigger — start a transfer using the chosen release pattern.
+//
+//   POST /api/transfer/try-finally
+//   POST /api/transfer/implicit
+//   POST /api/transfer/early-release
+//
+// Optional query params: ?from=alice&to=bob&amount=30 (defaults shown).
+// ============================================================================
+app.http("StartTransfer", {
+  route: "transfer/{pattern}",
+  methods: ["POST"],
+  authLevel: "anonymous",
+  extraInputs: [df.input.durableClient()],
+  handler: async (request, context) => {
+    const client = df.getClient(context);
+    const pattern = request.params.pattern;
+    const orchestration = PATTERN_TO_ORCH[pattern];
+    if (!orchestration) {
+      return {
+        status: 400,
+        jsonBody: { error: `Unknown pattern '${pattern}'.`, validPatterns: Object.keys(PATTERN_TO_ORCH) },
+      };
+    }
+
+    const fromKey = request.query.get("from") || "alice";
+    const toKey = request.query.get("to") || "bob";
+    const amount = parseInt(request.query.get("amount") || "30", 10);
+
+    const instanceId = await client.startNew(orchestration, { input: { fromKey, toKey, amount } });
+    context.log(`Started '${orchestration}' (${pattern}) transfer with ID = '${instanceId}'.`);
+    return client.createCheckStatusResponse(request, instanceId);
+  },
+});
+
+// ============================================================================
+// HTTP trigger — read an account balance.  GET /api/balance?key=alice
+// ============================================================================
+app.http("GetBalance", {
+  route: "balance",
+  methods: ["GET"],
+  authLevel: "anonymous",
+  extraInputs: [df.input.durableClient()],
+  handler: async (request, context) => {
+    const client = df.getClient(context);
+    const key = request.query.get("key") || "alice";
+    const state = await client.readEntityState(new df.EntityId("account", key));
+    return { status: 200, jsonBody: { key, exists: state.entityExists, balance: state.entityState ?? null } };
+  },
+});

--- a/samples/durable-functions/javascript/CriticalSections/src/functions/usingPattern.js
+++ b/samples/durable-functions/javascript/CriticalSections/src/functions/usingPattern.js
@@ -1,0 +1,51 @@
+const df = require("durable-functions");
+
+// ============================================================================
+// Pattern 1 — `using` (zero-boilerplate auto-release) — JavaScript sample.
+//
+//   *** REQUIRES Node.js 24+ ***
+//
+// The `using` declaration (ECMAScript Explicit Resource Management) calls the
+// lock's [Symbol.dispose]() automatically when the block scope exits — even if
+// the body throws. It is the cleanest pattern: no try/finally, no manual
+// release(). Because it relies on native `using` support, it needs Node.js 24+.
+//
+// This orchestration lives in its own file so the other three patterns in
+// ./criticalSections.js still load on Node.js 18–22. If you are on an older
+// Node.js version, delete this file before running `func start` — the `using`
+// pattern (and the POST /api/transfer/using route) will then be unavailable.
+//
+// The `account` entity, `sendReceipt` activity, and the StartTransfer HTTP
+// trigger (which routes POST /api/transfer/using here) are registered in
+// ./criticalSections.js, which is always loaded alongside this file.
+// ============================================================================
+
+df.app.orchestration("transferUsing", function* (context) {
+  const { fromKey, toKey, amount } = context.df.getInput();
+  const src = new df.EntityId("account", fromKey);
+  const dst = new df.EntityId("account", toKey);
+
+  // Seed known starting balances so the sample is self-contained (outside the lock).
+  yield context.df.callEntity(src, "set", 100);
+  yield context.df.callEntity(dst, "set", 0);
+
+  let lockedInside;
+  {
+    using lock = yield context.df.lock(src, dst); // auto-released at block exit
+    const lockState = context.df.isLocked();
+    lockedInside = lockState.isLocked; // true (lockState.ownedLocks lists the locked entities)
+    yield context.df.callEntity(src, "add", -amount);
+    yield context.df.callEntity(dst, "add", amount);
+  } // <- lock[Symbol.dispose]() runs here, releasing the lock
+
+  const { isLocked: lockedAfter } = context.df.isLocked(); // false
+  const fromBalance = yield context.df.callEntity(src, "get");
+  const toBalance = yield context.df.callEntity(dst, "get");
+
+  return {
+    pattern: "using",
+    lockedInside,
+    lockedAfter,
+    balances: { [fromKey]: fromBalance, [toKey]: toBalance },
+  };
+});

--- a/samples/durable-functions/typescript/CriticalSections/.gitignore
+++ b/samples/durable-functions/typescript/CriticalSections/.gitignore
@@ -1,0 +1,4 @@
+bin/
+obj/
+dist/
+node_modules/

--- a/samples/durable-functions/typescript/CriticalSections/NuGet.Config
+++ b/samples/durable-functions/typescript/CriticalSections/NuGet.Config
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="utf-8"?>
+<configuration>
+  <packageSources>
+    <clear />
+    <!-- Restore the Durable extension packages from nuget.org only. -->
+    <add key="nuget.org" value="https://api.nuget.org/v3/index.json" />
+  </packageSources>
+</configuration>

--- a/samples/durable-functions/typescript/CriticalSections/README.md
+++ b/samples/durable-functions/typescript/CriticalSections/README.md
@@ -1,0 +1,149 @@
+# Critical Sections — Durable Functions TypeScript
+
+TypeScript | Durable Functions | Durable Task Scheduler
+
+## Description
+
+This sample demonstrates **critical sections** — the ability to lock one or more
+[durable entities](https://learn.microsoft.com/azure/azure-functions/durable/durable-functions-entities)
+so that only one orchestration at a time can operate on them. Locks make
+multi-entity operations (like transferring money between two accounts) safe and
+atomic.
+
+The lock API was added in **durable-functions 3.4.0** and requires the
+**Microsoft.Azure.WebJobs.Extensions.DurableTask 3.13.0** extension. Acquire a
+lock with `context.df.lock(...)`, which returns a `DurableLock` you can release
+explicitly, dispose automatically, or let the extension free for you.
+
+```ts
+using lock = yield context.df.lock(src, dst);
+yield context.df.callEntity(src, "add", -amount);
+yield context.df.callEntity(dst, "add", amount);
+// lock auto-released at block scope exit, even on throw
+```
+
+### Release patterns demonstrated
+
+All four patterns live in [criticalSections.ts](src/functions/criticalSections.ts):
+
+| Pattern | Boilerplate | Exception-safe? | Hold time | Min TypeScript | Min Node |
+|---------|-------------|-----------------|-----------|----------------|----------|
+| `using` | None | ✅ Automatic | Block scope | 5.2+ | 18+ |
+| `try / finally` | 3 lines | ✅ If written correctly | Block scope | Any | 18+ |
+| Implicit (no release) | None | ✅ Always | **Entire orchestration** | Any | 18+ |
+| `try / finally` + early `release()` | 4 lines | ✅ + minimal hold time | Until first release | Any | 18+ |
+
+> **The `using` pattern needs TypeScript 5.2+.** It uses the `using` declaration
+> (ECMAScript Explicit Resource Management). TypeScript 5.2+ compiles `using`
+> down to a `Symbol.dispose` helper, so the **compiled** sample runs on
+> Node.js 18+ — no Node.js 24 requirement. The `tsconfig.json` here targets
+> `es2022` and includes the `esnext.disposable` lib so `using` type-checks and
+> compiles. (In raw JavaScript, `using` instead requires Node.js 24+ — see the
+> JavaScript sample.)
+
+## Prerequisites
+
+1. [Node.js 18+](https://nodejs.org/)
+2. [TypeScript 5.2+](https://www.typescriptlang.org/) (installed as a dev dependency)
+3. [Azure Functions Core Tools v4](https://learn.microsoft.com/azure/azure-functions/functions-run-local) (4.0.5382 or higher)
+4. [.NET SDK 8.0+](https://dotnet.microsoft.com/download) (to build/install the extension)
+5. [Docker](https://www.docker.com/products/docker-desktop/) (for the Durable Task Scheduler emulator)
+
+## Install the Durable extension manually
+
+The 3.13.0 extension that powers critical sections is **not yet in the Azure
+Functions extension bundles**, so this sample does **not** use a bundle. Instead,
+it ships an [extensions.csproj](extensions.csproj) that references the required
+packages, and you build it once to generate `bin/extensions.json`:
+
+```bash
+cd samples/durable-functions/typescript/CriticalSections
+dotnet build extensions.csproj -o bin
+```
+
+This restores from nuget.org and writes the extension assemblies plus
+`extensions.json` into `bin/`, where the Functions host loads them. You only need
+to run this once (or whenever you change [extensions.csproj](extensions.csproj)).
+
+> **Why no `extensionBundle` in host.json?** Extension bundles pin a fixed set of
+> extension versions. Because 3.13.0 isn't in a published bundle yet at the time of publishing this sample,
+> we remove the `extensionBundle` section and install the extension explicitly. Once a
+> bundle ships with 3.13.0+, you can switch back to a bundle and delete
+> `extensions.csproj`, `NuGet.Config`, and the `bin/`/`obj/` folders. Check the
+> [Extension Bundles Release](https://github.com/Azure/azure-functions-extension-bundles/releases)
+> page to check if 3.13.0 is published.
+
+The extension packages installed (see [extensions.csproj](extensions.csproj)):
+
+| Package | Version | Purpose |
+|---------|---------|---------|
+| `Microsoft.Azure.WebJobs.Extensions.DurableTask` | 3.13.0 | Durable extension with critical-section (lock) support |
+| `Microsoft.Azure.WebJobs.Extensions.DurableTask.AzureManaged` | 1.9.0 | Durable Task Scheduler (azureManaged) backend |
+| `Microsoft.Azure.WebJobs.Script.ExtensionsMetadataGenerator` | 4.0.1 | Generates `bin/extensions.json` |
+
+## Run the sample
+
+1. Start the Durable Task Scheduler emulator:
+
+   ```bash
+   docker run -d -p 8080:8080 -p 8082:8082 mcr.microsoft.com/dts/dts-emulator:latest
+   ```
+
+2. Install the extension (once), install dependencies, build, and start the host:
+
+   ```bash
+   dotnet build extensions.csproj -o bin
+   npm install
+   npm run build
+   func start
+   ```
+
+3. Start a transfer with one of the release patterns:
+
+   ```bash
+   curl -X POST http://localhost:7071/api/transfer/using
+   curl -X POST http://localhost:7071/api/transfer/try-finally
+   curl -X POST http://localhost:7071/api/transfer/implicit
+   curl -X POST http://localhost:7071/api/transfer/early-release
+   ```
+
+   Optional query parameters: `?from=alice&to=bob&amount=30` (defaults shown).
+
+4. Follow the `statusQueryGetUri` returned by the call to see the orchestration
+   output, or read an account balance directly:
+
+   ```bash
+   curl "http://localhost:7071/api/balance?key=alice"
+   curl "http://localhost:7071/api/balance?key=bob"
+   ```
+
+5. View instances in the dashboard: http://localhost:8082
+
+## Expected output
+
+Each transfer seeds `alice = 100` and `bob = 0`, then moves `amount` from `alice`
+to `bob` inside a critical section. The orchestration output shows the lock state
+and the resulting balances, for example (`using`):
+
+```json
+{
+  "pattern": "using",
+  "lockedInside": true,
+  "lockedAfter": false,
+  "balances": { "alice": 70, "bob": 30 }
+}
+```
+
+- `lockedInside` is `true` while the critical section is active.
+- `lockedAfter` is `false` once the lock is released — **except** for the
+  `implicit` pattern, where it stays `true` because the extension only frees the
+  lock when the orchestration ends.
+- The `early-release` result additionally includes `lockedAfterEarlyRelease`
+  (`false`) and a `receipt`, showing that non-critical work ran after the lock
+  was freed.
+
+## Learn more
+
+- [Durable entities](https://learn.microsoft.com/azure/azure-functions/durable/durable-functions-entities)
+- [Durable Functions JavaScript/TypeScript API reference](https://learn.microsoft.com/javascript/api/durable-functions/)
+- [Durable Task Scheduler documentation](https://aka.ms/dts-documentation)

--- a/samples/durable-functions/typescript/CriticalSections/README.md
+++ b/samples/durable-functions/typescript/CriticalSections/README.md
@@ -26,10 +26,10 @@ yield context.df.callEntity(dst, "add", amount);
 
 All four patterns live in [criticalSections.ts](src/functions/criticalSections.ts):
 
-| Pattern | Boilerplate | Exception-safe? | Hold time | Min TypeScript | Min Node |
-|---------|-------------|-----------------|-----------|----------------|----------|
+| Pattern | Boilerplate | Lock released on error? | Hold time | Min TypeScript | Min Node |
+|---------|-------------|-------------------------|-----------|----------------|----------|
 | `using` | None | ✅ Automatic | Block scope | 5.2+ | 18+ |
-| `try / finally` | 3 lines | ✅ If written correctly | Block scope | Any | 18+ |
+| `try / finally` | 3 lines | ✅ If `release()` is in `finally` | Block scope | Any | 18+ |
 | Implicit (no release) | None | ✅ Always | **Entire orchestration** | Any | 18+ |
 | `try / finally` + early `release()` | 4 lines | ✅ + minimal hold time | Until first release | Any | 18+ |
 

--- a/samples/durable-functions/typescript/CriticalSections/extensions.csproj
+++ b/samples/durable-functions/typescript/CriticalSections/extensions.csproj
@@ -1,0 +1,15 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net8.0</TargetFramework>
+    <!-- Keep the function app payload (node_modules, dist) when building into bin/. -->
+    <_FunctionsSkipCleanOutput>true</_FunctionsSkipCleanOutput>
+  </PropertyGroup>
+  <ItemGroup>
+    <!-- Generates bin/extensions.json so the host loads the manually installed extensions (no extension bundle). -->
+    <PackageReference Include="Microsoft.Azure.WebJobs.Script.ExtensionsMetadataGenerator" Version="4.0.1" />
+    <!-- Released Durable extension that supports the OOProc schema V4 required by critical sections / lock. -->
+    <PackageReference Include="Microsoft.Azure.WebJobs.Extensions.DurableTask" Version="3.13.0" />
+    <!-- Durable Task Scheduler (azureManaged) backend provider. -->
+    <PackageReference Include="Microsoft.Azure.WebJobs.Extensions.DurableTask.AzureManaged" Version="1.9.0" />
+  </ItemGroup>
+</Project>

--- a/samples/durable-functions/typescript/CriticalSections/host.json
+++ b/samples/durable-functions/typescript/CriticalSections/host.json
@@ -1,0 +1,17 @@
+{
+  "version": "2.0",
+  "logging": {
+    "logLevel": {
+      "DurableTask.Core": "Warning"
+    }
+  },
+  "extensions": {
+    "durableTask": {
+      "hubName": "default",
+      "storageProvider": {
+        "type": "azureManaged",
+        "connectionStringName": "DURABLE_TASK_SCHEDULER_CONNECTION_STRING"
+      }
+    }
+  }
+}

--- a/samples/durable-functions/typescript/CriticalSections/package-lock.json
+++ b/samples/durable-functions/typescript/CriticalSections/package-lock.json
@@ -1,0 +1,517 @@
+{
+  "name": "durable-functions-critical-sections-ts",
+  "version": "1.0.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "durable-functions-critical-sections-ts",
+      "version": "1.0.0",
+      "dependencies": {
+        "@azure/functions": "^4.0.0",
+        "durable-functions": "^3.4.0"
+      },
+      "devDependencies": {
+        "@types/node": "^18.0.0",
+        "typescript": "^5.2.0"
+      }
+    },
+    "node_modules/@azure/functions": {
+      "version": "4.16.1",
+      "resolved": "https://registry.npmjs.org/@azure/functions/-/functions-4.16.1.tgz",
+      "integrity": "sha512-A9obwC7IBg4NAmxUfTVfYEd8Xg6Px+o85JRprS3UJZt+GYYzIOmEecnFwTe3rl+aiHDewBk/8fnIVrSjR/fNGQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@azure/functions-extensions-base": "0.3.0",
+        "cookie": "^0.7.0"
+      },
+      "engines": {
+        "node": ">=20.0"
+      }
+    },
+    "node_modules/@azure/functions-extensions-base": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/@azure/functions-extensions-base/-/functions-extensions-base-0.3.0.tgz",
+      "integrity": "sha512-Cux0hLu5ZXlC/Kb+yvJVhRLIdkfFwui2HeT5oGZL00r/GCUUkhGTzRfZUjRN4Bq729mPv3okPucz2z7SMQLStA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18.0"
+      }
+    },
+    "node_modules/@opentelemetry/api": {
+      "version": "1.9.1",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/api/-/api-1.9.1.tgz",
+      "integrity": "sha512-gLyJlPHPZYdAk1JENA9LeHejZe1Ti77/pTeFm/nMXmQH/HFZlcS/O2XJB+L8fkbrNSqhdtlvjBVjxwUYanNH5Q==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=8.0.0"
+      }
+    },
+    "node_modules/@types/node": {
+      "version": "18.19.130",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-18.19.130.tgz",
+      "integrity": "sha512-GRaXQx6jGfL8sKfaIDD6OupbIHBr9jv7Jnaml9tB7l4v068PAOXqfcujMMo5PhbIs6ggR1XODELqahT2R8v0fg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~5.26.4"
+      }
+    },
+    "node_modules/agent-base": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-6.0.2.tgz",
+      "integrity": "sha512-RZNwNclF7+MS/8bDg70amg32dyeZGZxiDuQmZxKLAlQjr3jGyLx+4Kkk58UO7D2QdgFIQCovuSuZESne6RG6XQ==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "4"
+      },
+      "engines": {
+        "node": ">= 6.0.0"
+      }
+    },
+    "node_modules/agent-base/node_modules/debug": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/agent-base/node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "license": "MIT"
+    },
+    "node_modules/asynckit": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
+      "integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==",
+      "license": "MIT"
+    },
+    "node_modules/axios": {
+      "version": "1.18.1",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.18.1.tgz",
+      "integrity": "sha512-3nTvFlvpn9Zu/RkHUqtc7/+al4UpRW5az71ap5zccp6e8RAYEzhMTecX8Dz1wWDYrPpUoB1HAQEGEAEvUr7S9g==",
+      "license": "MIT",
+      "dependencies": {
+        "follow-redirects": "^1.16.0",
+        "form-data": "^4.0.5",
+        "https-proxy-agent": "^5.0.1",
+        "proxy-from-env": "^2.1.0"
+      }
+    },
+    "node_modules/call-bind-apply-helpers": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/call-bind-apply-helpers/-/call-bind-apply-helpers-1.0.2.tgz",
+      "integrity": "sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "function-bind": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/combined-stream": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
+      "integrity": "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==",
+      "license": "MIT",
+      "dependencies": {
+        "delayed-stream": "~1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/cookie": {
+      "version": "0.7.2",
+      "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.7.2.tgz",
+      "integrity": "sha512-yki5XnKuf750l50uGTllt6kKILY4nQ1eNIQatoXEByZ5dWgnKqbnqmTrBE5B4N7lrMJKQ2ytWMiTO2o0v6Ew/w==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/debug": {
+      "version": "2.6.9",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+      "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+      "license": "MIT",
+      "dependencies": {
+        "ms": "2.0.0"
+      }
+    },
+    "node_modules/delayed-stream": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
+      "integrity": "sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.4.0"
+      }
+    },
+    "node_modules/dunder-proto": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/dunder-proto/-/dunder-proto-1.0.1.tgz",
+      "integrity": "sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.1",
+        "es-errors": "^1.3.0",
+        "gopd": "^1.2.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/durable-functions": {
+      "version": "3.4.0",
+      "resolved": "https://registry.npmjs.org/durable-functions/-/durable-functions-3.4.0.tgz",
+      "integrity": "sha512-Wwgvcz/ccA7cIDo3lnbYusrys1KHJ+UII5RuMxk7lVejcG22HZR4L5EWidWaEKDayjLIvMg7W+u4S3EpdewJUg==",
+      "license": "MIT",
+      "dependencies": {
+        "@azure/functions": "^4.14.0",
+        "@opentelemetry/api": "^1.9.0",
+        "axios": "^1.16.1",
+        "debug": "~2.6.9",
+        "lodash": "^4.18.1",
+        "moment": "^2.29.2",
+        "uuid": "^9.0.1",
+        "validator": "~13.15.20"
+      },
+      "engines": {
+        "node": ">=18.0"
+      }
+    },
+    "node_modules/es-define-property": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/es-define-property/-/es-define-property-1.0.1.tgz",
+      "integrity": "sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-errors": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/es-errors/-/es-errors-1.3.0.tgz",
+      "integrity": "sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-object-atoms": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.1.2.tgz",
+      "integrity": "sha512-HWcBoN6NileqtSydK2FqHbS/LoDd2pqrnQHLyJzBj4kOp/ky2MWMN694xOfkK8/SnUsW2DH7EfyVlydKCsm1Zw==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-set-tostringtag": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/es-set-tostringtag/-/es-set-tostringtag-2.1.0.tgz",
+      "integrity": "sha512-j6vWzfrGVfyXxge+O0x5sh6cvxAog0a/4Rdd2K36zCMV5eJ+/+tOAngRO8cODMNWbVRdVlmGZQL2YS3yR8bIUA==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.6",
+        "has-tostringtag": "^1.0.2",
+        "hasown": "^2.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/follow-redirects": {
+      "version": "1.16.0",
+      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.16.0.tgz",
+      "integrity": "sha512-y5rN/uOsadFT/JfYwhxRS5R7Qce+g3zG97+JrtFZlC9klX/W5hD7iiLzScI4nZqUS7DNUdhPgw4xI8W2LuXlUw==",
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://github.com/sponsors/RubenVerborgh"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=4.0"
+      },
+      "peerDependenciesMeta": {
+        "debug": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/form-data": {
+      "version": "4.0.6",
+      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.6.tgz",
+      "integrity": "sha512-vKatAh4SlVfgbv+YtmhiRjhEMJsYpsG1Y2rMQtR+SVSbytsSD1YGzDIcrAJmdFec88u/+VoGmxnl+80gL1tRCQ==",
+      "license": "MIT",
+      "dependencies": {
+        "asynckit": "^0.4.0",
+        "combined-stream": "^1.0.8",
+        "es-set-tostringtag": "^2.1.0",
+        "hasown": "^2.0.4",
+        "mime-types": "^2.1.35"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/function-bind": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.2.tgz",
+      "integrity": "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/get-intrinsic": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.3.0.tgz",
+      "integrity": "sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.2",
+        "es-define-property": "^1.0.1",
+        "es-errors": "^1.3.0",
+        "es-object-atoms": "^1.1.1",
+        "function-bind": "^1.1.2",
+        "get-proto": "^1.0.1",
+        "gopd": "^1.2.0",
+        "has-symbols": "^1.1.0",
+        "hasown": "^2.0.2",
+        "math-intrinsics": "^1.1.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/get-proto": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/get-proto/-/get-proto-1.0.1.tgz",
+      "integrity": "sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g==",
+      "license": "MIT",
+      "dependencies": {
+        "dunder-proto": "^1.0.1",
+        "es-object-atoms": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/gopd": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/gopd/-/gopd-1.2.0.tgz",
+      "integrity": "sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/has-symbols": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.1.0.tgz",
+      "integrity": "sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/has-tostringtag": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/has-tostringtag/-/has-tostringtag-1.0.2.tgz",
+      "integrity": "sha512-NqADB8VjPFLM2V0VvHUewwwsw0ZWBaIdgo+ieHtK3hasLz4qeCRjYcqfB6AQrBggRKppKF8L52/VqdVsO47Dlw==",
+      "license": "MIT",
+      "dependencies": {
+        "has-symbols": "^1.0.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/hasown": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.4.tgz",
+      "integrity": "sha512-T2UbfbBEF32wiepXIsMlTW9+dDYC6wMh/t/vYA4tuOMKqWz/n3vr1NFSxQiyP+zk2mXsoMA/i/7qV6LKut1t1A==",
+      "license": "MIT",
+      "dependencies": {
+        "function-bind": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/https-proxy-agent": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-5.0.1.tgz",
+      "integrity": "sha512-dFcAjpTQFgoLMzC2VwU+C/CbS7uRL0lWmxDITmqm7C+7F0Odmj6s9l6alZc6AELXhrnggM2CeWSXHGOdX2YtwA==",
+      "license": "MIT",
+      "dependencies": {
+        "agent-base": "6",
+        "debug": "4"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/https-proxy-agent/node_modules/debug": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/https-proxy-agent/node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "license": "MIT"
+    },
+    "node_modules/lodash": {
+      "version": "4.18.1",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.18.1.tgz",
+      "integrity": "sha512-dMInicTPVE8d1e5otfwmmjlxkZoUpiVLwyeTdUsi/Caj/gfzzblBcCE5sRHV/AsjuCmxWrte2TNGSYuCeCq+0Q==",
+      "license": "MIT"
+    },
+    "node_modules/math-intrinsics": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/math-intrinsics/-/math-intrinsics-1.1.0.tgz",
+      "integrity": "sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/mime-db": {
+      "version": "1.52.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.52.0.tgz",
+      "integrity": "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/mime-types": {
+      "version": "2.1.35",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.35.tgz",
+      "integrity": "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==",
+      "license": "MIT",
+      "dependencies": {
+        "mime-db": "1.52.0"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/moment": {
+      "version": "2.30.1",
+      "resolved": "https://registry.npmjs.org/moment/-/moment-2.30.1.tgz",
+      "integrity": "sha512-uEmtNhbDOrWPFS+hdjFCBfy9f2YoyzRpwcl+DqpC6taX21FzsTLQVbMV/W7PzNSX6x/bhC1zA3c2UQ5NzH6how==",
+      "license": "MIT",
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/ms": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+      "integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A==",
+      "license": "MIT"
+    },
+    "node_modules/proxy-from-env": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-2.1.0.tgz",
+      "integrity": "sha512-cJ+oHTW1VAEa8cJslgmUZrc+sjRKgAKl3Zyse6+PV38hZe/V6Z14TbCuXcan9F9ghlz4QrFr2c92TNF82UkYHA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/typescript": {
+      "version": "5.9.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
+      "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
+      }
+    },
+    "node_modules/undici-types": {
+      "version": "5.26.5",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-5.26.5.tgz",
+      "integrity": "sha512-JlCMO+ehdEIKqlFxk6IfVoAUVmgz7cU7zD/h9XZ0qzeosSHmUJVOzSQvvYSYWXkFXC+IfLKSIffhv0sVZup6pA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/uuid": {
+      "version": "9.0.1",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-9.0.1.tgz",
+      "integrity": "sha512-b+1eJOlsR9K8HJpow9Ok3fiWOWSIcIzXodvv0rQjVoOVNpWMpxf1wZNpt4y9h10odCNrqnYp1OBzRktckBe3sA==",
+      "deprecated": "uuid@10 and below is no longer supported.  For ESM codebases, update to uuid@latest.  For CommonJS codebases, use uuid@11 (but be aware this version will likely be deprecated in 2028).",
+      "funding": [
+        "https://github.com/sponsors/broofa",
+        "https://github.com/sponsors/ctavan"
+      ],
+      "license": "MIT",
+      "bin": {
+        "uuid": "dist/bin/uuid"
+      }
+    },
+    "node_modules/validator": {
+      "version": "13.15.35",
+      "resolved": "https://registry.npmjs.org/validator/-/validator-13.15.35.tgz",
+      "integrity": "sha512-TQ5pAGhd5whStmqWvYF4OjQROlmv9SMFVt37qoCBdqRffuuklWYQlCNnEs2ZaIBD1kZRNnikiZOS1eqgkar0iw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.10"
+      }
+    }
+  }
+}

--- a/samples/durable-functions/typescript/CriticalSections/package.json
+++ b/samples/durable-functions/typescript/CriticalSections/package.json
@@ -1,0 +1,19 @@
+{
+  "name": "durable-functions-critical-sections-ts",
+  "version": "1.0.0",
+  "description": "Durable Functions TypeScript sample: entity critical sections (locks) with the Durable Task Scheduler backend",
+  "main": "dist/src/functions/*.js",
+  "scripts": {
+    "build": "tsc",
+    "prestart": "npm run build",
+    "start": "func start"
+  },
+  "dependencies": {
+    "@azure/functions": "^4.0.0",
+    "durable-functions": "^3.4.0"
+  },
+  "devDependencies": {
+    "@types/node": "^18.0.0",
+    "typescript": "^5.2.0"
+  }
+}

--- a/samples/durable-functions/typescript/CriticalSections/src/functions/criticalSections.ts
+++ b/samples/durable-functions/typescript/CriticalSections/src/functions/criticalSections.ts
@@ -1,0 +1,266 @@
+import { app, HttpRequest, HttpResponseInit, InvocationContext } from "@azure/functions";
+import * as df from "durable-functions";
+
+interface TransferInput {
+  fromKey: string;
+  toKey: string;
+  amount: number;
+}
+
+// ============================================================================
+// Critical sections (entity locks) — TypeScript sample.
+//
+// Feature: context.df.lock(...) acquires a critical section over one or more
+// entities so that only one orchestration at a time can operate on them. This
+// is the building block for safe, atomic multi-entity operations such as a
+// money transfer between two accounts.
+//
+//   - SDK:        durable-functions 3.4.0+
+//   - Extension:  Microsoft.Azure.WebJobs.Extensions.DurableTask 3.13.0+
+//                 (installed manually — see README; not in extension bundles yet)
+//   - Backend:    Durable Task Scheduler (azureManaged)
+//
+// All four lock-release patterns are demonstrated below. The `using` pattern
+// needs TypeScript 5.2+ to compile; once compiled it runs on Node.js 18+
+// (TypeScript emits the Symbol.dispose helper for older runtimes).
+// ============================================================================
+
+// ----------------------------------------------------------------------------
+// Account entity — stores a numeric balance and supports set / add / get.
+// ----------------------------------------------------------------------------
+df.app.entity("account", function (context) {
+  let balance = context.df.getState(() => 0) as number;
+  switch (context.df.operationName) {
+    case "set":
+      balance = context.df.getInput<number>() ?? 0;
+      break;
+    case "add":
+      balance += context.df.getInput<number>() ?? 0;
+      break;
+    case "get":
+      context.df.return(balance);
+      break;
+  }
+  context.df.setState(balance);
+});
+
+// ----------------------------------------------------------------------------
+// Activity used by the early-release pattern to do work AFTER the lock is freed.
+// ----------------------------------------------------------------------------
+df.app.activity("sendReceipt", {
+  handler: (input: TransferInput): string => `receipt:${input.fromKey}->${input.toKey}:${input.amount}`,
+});
+
+// ============================================================================
+// Pattern 1 — `using` (zero-boilerplate auto-release; TS 5.2+ / Node 18+)
+//
+// The `using` declaration disposes the lock automatically when the block scope
+// exits, even on throw. It is the cleanest pattern — no try/finally, no manual
+// release(). TypeScript downlevels `using` so it runs on Node.js 18+.
+// ============================================================================
+df.app.orchestration("transferUsing", function* (context) {
+  const { fromKey, toKey, amount } = context.df.getInput<TransferInput>();
+  const src = new df.EntityId("account", fromKey);
+  const dst = new df.EntityId("account", toKey);
+
+  // Seed known starting balances so the sample is self-contained (outside the lock).
+  yield context.df.callEntity(src, "set", 100);
+  yield context.df.callEntity(dst, "set", 0);
+
+  let lockedInside: boolean;
+  {
+    using lock = yield context.df.lock(src, dst); // auto-released at block exit
+    const lockState = context.df.isLocked();
+    lockedInside = lockState.isLocked; // true (lockState.ownedLocks lists the locked entities)
+    yield context.df.callEntity(src, "add", -amount);
+    yield context.df.callEntity(dst, "add", amount);
+  } // <- lock[Symbol.dispose]() runs here, releasing the lock
+
+  const { isLocked: lockedAfter } = context.df.isLocked(); // false
+  return yield* summarize(context, "using", src, dst, fromKey, toKey, {
+    lockedInside,
+    lockedAfter,
+  });
+});
+
+// ============================================================================
+// Pattern 2 — try / finally (explicit release in finally; any TS / Node 18+)
+//
+// The lock is held for the whole try block and released in finally, so it is
+// freed even if the body throws. This is the universal pattern: it works on
+// any Node.js/TypeScript version.
+// ============================================================================
+df.app.orchestration("transferTryFinally", function* (context) {
+  const { fromKey, toKey, amount } = context.df.getInput<TransferInput>();
+  const src = new df.EntityId("account", fromKey);
+  const dst = new df.EntityId("account", toKey);
+
+  yield context.df.callEntity(src, "set", 100);
+  yield context.df.callEntity(dst, "set", 0);
+
+  const lock = yield context.df.lock(src, dst);
+  const { isLocked: lockedInside } = context.df.isLocked(); // true — the lock is held
+  try {
+    yield context.df.callEntity(src, "add", -amount);
+    yield context.df.callEntity(dst, "add", amount);
+  } finally {
+    lock.release();
+  }
+
+  const { isLocked: lockedAfter } = context.df.isLocked(); // released -> false
+  return yield* summarize(context, "try/finally", src, dst, fromKey, toKey, {
+    lockedInside,
+    lockedAfter,
+  });
+});
+
+// ============================================================================
+// Pattern 3 — Implicit (no release; extension frees the lock at orch end)
+//
+// No release() call. The lock is held until the orchestration terminates, at
+// which point the extension releases it automatically. Always exception-safe,
+// but the lock is held for the entire orchestration — the longest hold time.
+// ============================================================================
+df.app.orchestration("transferImplicit", function* (context) {
+  const { fromKey, toKey, amount } = context.df.getInput<TransferInput>();
+  const src = new df.EntityId("account", fromKey);
+  const dst = new df.EntityId("account", toKey);
+
+  yield context.df.callEntity(src, "set", 100);
+  yield context.df.callEntity(dst, "set", 0);
+
+  yield context.df.lock(src, dst);
+  const { isLocked: lockedInside } = context.df.isLocked(); // true
+  yield context.df.callEntity(src, "add", -amount);
+  yield context.df.callEntity(dst, "add", amount);
+  // No release(). lockedAfter stays true here; the extension frees the lock
+  // when the orchestration completes.
+
+  const { isLocked: lockedAfter } = context.df.isLocked(); // still true
+  return yield* summarize(context, "implicit", src, dst, fromKey, toKey, {
+    lockedInside,
+    lockedAfter,
+  });
+});
+
+// ============================================================================
+// Pattern 4 — try / finally + early release (any TS / Node 18+)
+//
+// Release the lock as soon as the critical work is done, then continue with
+// non-critical work (here, sending a receipt) while OTHER orchestrations are
+// free to acquire the lock. The finally block's release() is an idempotent
+// safety net in case the body throws before the early release runs.
+// ============================================================================
+df.app.orchestration("transferEarlyRelease", function* (context) {
+  const { fromKey, toKey, amount } = context.df.getInput<TransferInput>();
+  const src = new df.EntityId("account", fromKey);
+  const dst = new df.EntityId("account", toKey);
+
+  yield context.df.callEntity(src, "set", 100);
+  yield context.df.callEntity(dst, "set", 0);
+
+  const lock = yield context.df.lock(src, dst);
+  const { isLocked: lockedInside } = context.df.isLocked(); // true — the lock is held
+  try {
+    yield context.df.callEntity(src, "add", -amount);
+    yield context.df.callEntity(dst, "add", amount);
+
+    lock.release(); // release early — other orchestrations can now proceed
+    const { isLocked: lockedAfterEarlyRelease } = context.df.isLocked(); // false
+
+    // Non-critical work done AFTER the lock is freed.
+    const receipt = yield context.df.callActivity("sendReceipt", { fromKey, toKey, amount });
+
+    const { isLocked: lockedAfter } = context.df.isLocked(); // false
+    return yield* summarize(context, "try/finally+early", src, dst, fromKey, toKey, {
+      lockedInside,
+      lockedAfterEarlyRelease,
+      receipt,
+      lockedAfter,
+    });
+  } finally {
+    lock.release(); // idempotent safety net; no-op if already released
+  }
+});
+
+// ----------------------------------------------------------------------------
+// Helper: read the final balances (unlocked get calls) and build the result.
+// Implemented as a generator so it can `yield` durable calls from the caller.
+// ----------------------------------------------------------------------------
+function* summarize(
+  context: df.OrchestrationContext,
+  pattern: string,
+  src: df.EntityId,
+  dst: df.EntityId,
+  fromKey: string,
+  toKey: string,
+  extra: Record<string, unknown>
+): Generator<df.Task, Record<string, unknown>, any> {
+  const fromBalance = yield context.df.callEntity(src, "get");
+  const toBalance = yield context.df.callEntity(dst, "get");
+  return {
+    pattern,
+    ...extra,
+    balances: { [fromKey]: fromBalance, [toKey]: toBalance },
+  };
+}
+
+// Map the {pattern} route value to the orchestration name.
+const PATTERN_TO_ORCH: Record<string, string> = {
+  using: "transferUsing",
+  "try-finally": "transferTryFinally",
+  implicit: "transferImplicit",
+  "early-release": "transferEarlyRelease",
+};
+
+// ============================================================================
+// HTTP trigger — start a transfer using the chosen release pattern.
+//
+//   POST /api/transfer/using
+//   POST /api/transfer/try-finally
+//   POST /api/transfer/implicit
+//   POST /api/transfer/early-release
+//
+// Optional query params: ?from=alice&to=bob&amount=30 (defaults shown).
+// ============================================================================
+app.http("StartTransfer", {
+  route: "transfer/{pattern}",
+  methods: ["POST"],
+  authLevel: "anonymous",
+  extraInputs: [df.input.durableClient()],
+  handler: async (request: HttpRequest, context: InvocationContext): Promise<HttpResponseInit> => {
+    const client = df.getClient(context);
+    const pattern = request.params.pattern;
+    const orchestration = PATTERN_TO_ORCH[pattern];
+    if (!orchestration) {
+      return {
+        status: 400,
+        jsonBody: { error: `Unknown pattern '${pattern}'.`, validPatterns: Object.keys(PATTERN_TO_ORCH) },
+      };
+    }
+
+    const fromKey = request.query.get("from") || "alice";
+    const toKey = request.query.get("to") || "bob";
+    const amount = parseInt(request.query.get("amount") || "30", 10);
+
+    const instanceId = await client.startNew(orchestration, { input: { fromKey, toKey, amount } });
+    context.log(`Started '${orchestration}' (${pattern}) transfer with ID = '${instanceId}'.`);
+    return client.createCheckStatusResponse(request, instanceId);
+  },
+});
+
+// ============================================================================
+// HTTP trigger — read an account balance.  GET /api/balance?key=alice
+// ============================================================================
+app.http("GetBalance", {
+  route: "balance",
+  methods: ["GET"],
+  authLevel: "anonymous",
+  extraInputs: [df.input.durableClient()],
+  handler: async (request: HttpRequest, context: InvocationContext): Promise<HttpResponseInit> => {
+    const client = df.getClient(context);
+    const key = request.query.get("key") || "alice";
+    const state = await client.readEntityState(new df.EntityId("account", key));
+    return { status: 200, jsonBody: { key, exists: state.entityExists, balance: state.entityState ?? null } };
+  },
+});

--- a/samples/durable-functions/typescript/CriticalSections/tsconfig.json
+++ b/samples/durable-functions/typescript/CriticalSections/tsconfig.json
@@ -1,0 +1,16 @@
+{
+  "compilerOptions": {
+    "module": "commonjs",
+    "target": "es2022",
+    "lib": ["es2022", "esnext.disposable"],
+    "outDir": "dist",
+    "rootDir": ".",
+    "sourceMap": true,
+    "strict": true,
+    "esModuleInterop": true,
+    "moduleResolution": "node",
+    "skipLibCheck": true,
+    "forceConsistentCasingInFileNames": true
+  },
+  "include": ["src/**/*.ts"]
+}


### PR DESCRIPTION
## Purpose
<!-- Describe the intention of the changes being proposed. What problem does it solve or functionality does it add? -->
* Adds two new samples — **JavaScript** and **TypeScript** — under `samples/durable-functions/` that demonstrate the **critical sections (entity locks)** feature newly added in `durable-functions` 3.4.0 (+ `Microsoft.Azure.WebJobs.Extensions.DurableTask` 3.13.0), running against the **Durable Task Scheduler (azureManaged)** backend.
* Demonstrates a money-transfer-between-two-accounts scenario and covers all four lock‑release patterns: `using` (auto-release), `try/finally`, implicit (extension releases at orchestration end), and `try/finally` + early `release()`.
* Each sample ships a README covering app setup **and how to manually install the 3.13.0 extension**, which is not yet available in the Azure Functions extension bundles.

## Does this introduce a breaking change?
<!-- Mark one with an "x". -->
```
[ ] Yes
[x] No
```

## Pull Request Type
What kind of change does this Pull Request introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[ ] Bugfix
[x] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Documentation content changes
[ ] Other... Please describe:
```

## How to Test
*  Get the code

```
git clone https://github.com/bachuv/Durable-Task-Scheduler
cd Durable-Task-Scheduler
git checkout vabachu/critical-sections-node-samples
```

* Test the code
<!-- Add steps to run the tests suite and/or manually test -->
```
# 1. Start the Durable Task Scheduler emulator (serves both samples)
docker run -d -p 8080:8080 -p 8082:8082 mcr.microsoft.com/dts/dts-emulator:latest

# --- TypeScript sample ---
cd samples/durable-functions/typescript/CriticalSections
dotnet build extensions.csproj -o bin    # manual extension install (3.13.0 not in bundles yet)
npm install
npm run build
func start                               # http://localhost:7071

# In a second terminal, run each release pattern:
curl -X POST http://localhost:7071/api/transfer/using
curl -X POST http://localhost:7071/api/transfer/try-finally
curl -X POST http://localhost:7071/api/transfer/implicit
curl -X POST http://localhost:7071/api/transfer/early-release
curl "http://localhost:7071/api/balance?key=alice"
curl "http://localhost:7071/api/balance?key=bob"

# --- JavaScript sample (stop the TS host first) ---
cd ../../javascript/CriticalSections
dotnet build extensions.csproj -o bin    # manual extension install
npm install
func start                               # http://localhost:7071
# then run the same four POST /api/transfer/<pattern> calls as above
```

## What to Check
Verify that the following are valid
* Each `POST /api/transfer/<pattern>` orchestration reaches **Completed** and returns lock-state diagnostics in its output.
* `lockedInside` is `true` for every pattern; `lockedAfter` is `false` for `using`, `try/finally`, and `early-release`, and `true` for `implicit` (the lock is held until the orchestration ends).
* The `early-release` result includes `lockedAfterEarlyRelease: false` and a `receipt`, proving non-critical work ran after the lock was freed.
* Balances finish at `alice = 70`, `bob = 30` for every pattern (transfer of 30 from a seeded 100/0).
* The manual extension install produces `bin/extensions.json` registering both `DurableTask` (3.13.0) and `AzureManagedProvider` (DTS backend), and the host starts with **no** `extensionBundle` in `host.json`.
* Each README's prerequisites, manual-install, and run steps are accurate.

## Other Information
<!-- Add any other helpful information that may be needed here. -->
* Uses the **published** npm `durable-functions@3.4.0` and the released NuGet `Microsoft.Azure.WebJobs.Extensions.DurableTask` 3.13.0 + `Microsoft.Azure.WebJobs.Extensions.DurableTask.AzureManaged` 1.9.0.
* The 3.13.0 extension is **not yet in extension bundles**, so the samples drop `extensionBundle` from `host.json` and ship an `extensions.csproj` + `NuGet.Config` that are built once with `dotnet build extensions.csproj -o bin`. Once a bundle ships with 3.13.0+, these files can be removed and a bundle restored.
* The `using` pattern requires **Node.js 24+** in JavaScript (isolated in `usingPattern.js` so the other three patterns still run on Node 18+); in TypeScript it requires **TS 5.2+** and compiles down to run on Node 18+.
* Both samples were validated end-to-end against the DTS emulator — all four patterns Completed in each, with the DTS backend..
* Targets the same `samples/durable-functions/{javascript,typescript}/` structure and conventions as the existing `HelloCities` samples.
