### PR TITLE
Add Python samples for new DTS SDK features and apply replay-safe logging

### DIFF
--- a/docs/patterns.md
+++ b/docs/patterns.md
@@ -147,6 +147,24 @@ Process batch → Continue as new → Process batch → Continue as new → ...
 
 ---
 
+## Bounded Coordinator
+A coordinator that fans out child work in bounded batches, waits for all children, then resets history via `continue_as_new` after each batch.
+
+```
+Coordinator (batch N) → fan out children → wait all → continue_as_new → batch N+1
+```
+
+**Use cases:** Continuous queue draining, long-running ingestion/ETL pipelines, message-pump coordinators that must avoid history bloat
+
+| Language | Durable Task SDK | Durable Functions |
+|----------|-----------------|-------------------|
+| .NET | [Sample](../samples/durable-task-sdks/dotnet/BoundedCoordinator) | — |
+| Python | [Sample](../samples/durable-task-sdks/python/bounded-coordinator) | — |
+
+📖 [Learn more on Microsoft Learn →](https://learn.microsoft.com/azure/azure-functions/durable/durable-functions-eternal-orchestrations)
+
+---
+
 ## Durable Entities
 Stateful objects that persist their state and support operations via messages.
 
@@ -196,6 +214,22 @@ Safely evolve orchestration logic without breaking in-flight instances.
 | Python | [Sample](../samples/durable-task-sdks/python/versioning) | — |
 
 📖 [Learn more on Microsoft Learn →](https://learn.microsoft.com/azure/azure-functions/durable/durable-functions-versioning)
+
+---
+
+## Scheduled Tasks
+Run a target orchestration on a recurring interval, with pause/resume and runtime management.
+
+```
+Schedule (every 5s) → Start orchestration → ... → Start orchestration
+```
+
+**Use cases:** Periodic background jobs, cache clearing, report generation, cron-like recurring workflows
+
+| Language | Durable Task SDK | Durable Functions |
+|----------|-----------------|-------------------|
+| .NET | [Schedule Web App](../samples/durable-task-sdks/dotnet/ScheduleWebApp) | — |
+| Python | [Sample](../samples/durable-task-sdks/python/scheduled-tasks) | — |
 
 ---
 

--- a/samples/README.md
+++ b/samples/README.md
@@ -38,11 +38,13 @@ A quick-reference matrix showing which patterns are available in each language a
 | Durable Entities | [✅](./durable-task-sdks/dotnet/EntitiesSample) | [✅](./durable-task-sdks/python/entities) | | |
 | Orchestration Versioning | [✅](./durable-task-sdks/dotnet/OrchestrationVersioning) | [✅](./durable-task-sdks/python/versioning) | | |
 | ASP.NET Web API | [✅](./durable-task-sdks/dotnet/AspNetWebApp) | | | |
-| Scheduled Tasks | [✅](./durable-task-sdks/dotnet/ScheduleWebApp) | | | |
+| Scheduled Tasks | [✅](./durable-task-sdks/dotnet/ScheduleWebApp) | [✅](./durable-task-sdks/python/scheduled-tasks) | | |
 | .NET Aspire Integration | [✅](./durable-task-sdks/dotnet/DtsWithAspire) | | | |
 | AI Agent Chaining | [✅](./durable-task-sdks/dotnet/Agents/PromptChaining) | | | |
 | AI Research Agent | | [✅](./durable-task-sdks/python/arXiv_research_agent) | | |
 | Large Payload | [✅](./durable-task-sdks/dotnet/LargePayload) | | | |
+| Export History | [✅](./durable-task-sdks/dotnet/ExportHistoryWebApp) | [✅](./durable-task-sdks/python/history-export) | | |
+| Bounded Coordinator | [✅](./durable-task-sdks/dotnet/BoundedCoordinator) | [✅](./durable-task-sdks/python/bounded-coordinator) | | |
 
 ### Durable Functions
 

--- a/samples/durable-task-sdks/python/async-http-api/worker.py
+++ b/samples/durable-task-sdks/python/async-http-api/worker.py
@@ -37,12 +37,14 @@ def async_http_api_orchestrator(ctx, input_data: dict) -> dict:
     This orchestrator starts a long-running operation and returns its result.
     """
     operation_id = input_data.get("operation_id", "unknown")
-    logger.info(f"Starting async HTTP API orchestration for operation {operation_id}")
+    # Use a replay-safe logger so these lines are not re-emitted on every replay.
+    olog = ctx.create_replay_safe_logger(logger)
+    olog.info(f"Starting async HTTP API orchestration for operation {operation_id}")
     
     # Execute the long-running operation
     result = yield ctx.call_activity("process_long_running_operation", input=input_data)
     
-    logger.info(f"Completed orchestration for operation {operation_id}")
+    olog.info(f"Completed orchestration for operation {operation_id}")
     return result
 
 async def main():

--- a/samples/durable-task-sdks/python/bounded-coordinator/README.md
+++ b/samples/durable-task-sdks/python/bounded-coordinator/README.md
@@ -1,0 +1,223 @@
+# Bounded Coordinator
+
+Python | Durable Task SDK
+
+## Description of the Sample
+
+This sample demonstrates the **bounded coordinator** pattern with the Azure Durable Task Scheduler using the Python SDK. A parent orchestration fans out child work in bounded batches, waits for all children to complete, and then resets its history via `continue_as_new` after each batch. This prevents the unbounded history growth that can occur with long-lived coordinator / message-pump orchestrations.
+
+This is the Python counterpart to the .NET [BoundedCoordinator](../../dotnet/BoundedCoordinator/) sample.
+
+In this sample:
+1. The coordinator reads a **bounded batch** of items via the `get_next_batch` activity
+2. It fans out child sub-orchestrations (`process_item_orchestrator`) for each item in the batch
+3. It **waits for all children** to complete with `task.when_all`
+4. If more work remains, it calls `continue_as_new` with compact carry-forward state
+5. The orchestration restarts with a clean history and processes the next batch
+
+This pattern is important because:
+- Long-lived coordinators accumulate history events on every replay
+- Without periodic resets, history can grow to tens of thousands of events
+- Large histories cause increasingly expensive replays and can lead to persistence failures in backing stores
+
+This pattern is useful for:
+- Continuously draining a queue or work source in batches
+- Long-running ingestion / ETL pipelines
+- Any "message pump" style coordinator that must run indefinitely without history bloat
+
+## Prerequisites
+
+1. [Python 3.10+](https://www.python.org/downloads/)
+2. [Docker](https://www.docker.com/products/docker-desktop/) (for running the emulator)
+3. [Azure CLI](https://docs.microsoft.com/cli/azure/install-azure-cli) (if using a deployed Durable Task Scheduler)
+
+## Configuring Durable Task Scheduler
+
+There are two ways to run this sample locally:
+
+### Using the Emulator (Recommended)
+
+The emulator simulates a scheduler and taskhub in a Docker container, making it ideal for development and learning.
+
+1. Pull the Docker Image for the Emulator:
+   ```bash
+   docker pull mcr.microsoft.com/dts/dts-emulator:latest
+   ```
+
+2. Run the Emulator:
+   ```bash
+   docker run --name dtsemulator -d -p 8080:8080 -p 8082:8082 mcr.microsoft.com/dts/dts-emulator:latest
+   ```
+
+Wait a few seconds for the container to be ready.
+
+Note: The example code automatically uses the default emulator settings (endpoint: `http://localhost:8080`, taskhub: `default`). You don't need to set any environment variables.
+
+### Using a Deployed Scheduler and Taskhub in Azure
+
+Local development with a deployed scheduler:
+
+1. Install the durable task scheduler CLI extension:
+
+    ```bash
+    az upgrade
+    az extension add --name durabletask --allow-preview true
+    ```
+
+2. Create a resource group in a region where the Durable Task Scheduler is available:
+
+    ```bash
+    az provider show --namespace Microsoft.DurableTask --query "resourceTypes[?resourceType=='schedulers'].locations | [0]" --out table
+    ```
+
+    ```bash
+    az group create --name my-resource-group --location <location>
+    ```
+
+3. Create a durable task scheduler resource:
+
+    ```bash
+    az durabletask scheduler create \
+        --resource-group my-resource-group \
+        --name my-scheduler \
+        --ip-allowlist '["0.0.0.0/0"]' \
+        --sku-name "Dedicated" \
+        --sku-capacity 1 \
+        --tags "{'myattribute':'myvalue'}"
+    ```
+
+4. Create a task hub within the scheduler resource:
+
+    ```bash
+    az durabletask taskhub create \
+        --resource-group my-resource-group \
+        --scheduler-name my-scheduler \
+        --name "my-taskhub"
+    ```
+
+5. Grant the current user permission to connect to the `my-taskhub` task hub:
+
+    ```bash
+    subscriptionId=$(az account show --query "id" -o tsv)
+    loggedInUser=$(az account show --query "user.name" -o tsv)
+
+    az role assignment create \
+        --assignee $loggedInUser \
+        --role "Durable Task Data Contributor" \
+        --scope "/subscriptions/$subscriptionId/resourceGroups/my-resource-group/providers/Microsoft.DurableTask/schedulers/my-scheduler/taskHubs/my-taskhub"
+    ```
+
+## How to Run the Sample
+
+Once you have set up either the emulator or deployed scheduler, follow these steps to run the sample:
+
+1. First, activate your Python virtual environment (if you're using one):
+   ```bash
+   python -m venv venv
+   source venv/bin/activate  # On Windows, use: venv\Scripts\activate
+   ```
+
+2. If you're using a deployed scheduler, set environment variables:
+   ```bash
+   export ENDPOINT=$(az durabletask scheduler show \
+       --resource-group my-resource-group \
+       --name my-scheduler \
+       --query "properties.endpoint" \
+       --output tsv)
+
+   export TASKHUB="my-taskhub"
+   ```
+
+3. Install the required packages:
+   ```bash
+   pip install -r requirements.txt
+   ```
+
+4. Start the worker in a terminal:
+   ```bash
+   python worker.py
+   ```
+
+5. In a new terminal (with the virtual environment activated if applicable), run the client:
+   > **Note:** Remember to set the environment variables again if you're using a deployed scheduler.
+
+   ```bash
+   python client.py
+   ```
+
+## Expected Output
+
+### Client Output
+```
+Started coordinator_orchestrator, instance ID: <instance-id>
+
+Completed with status: OrchestrationStatus.COMPLETED
+Result: {"total_batches": 3, "completed": true}
+```
+
+### Worker Output
+```
+Coordinator batch 0, cursor=(start)
+Processing batch of 5 items
+Processing item item-1-1 for tenant tenant-1
+Applying change for item item-1-1, tenant tenant-1
+...
+Batch 1 complete. 5 items processed.
+Coordinator batch 1, cursor=cursor-1
+...
+Batch 3 complete. 5 items processed.
+No more items to process. Coordinator completing.
+```
+
+## How It Works
+
+```
+coordinator_orchestrator (batch N)
+  ├─ get_next_batch (bounded: up to MAX_ITEMS)
+  ├─ fan out: process_item_orchestrator x batch size
+  ├─ task.when_all(children)   ← wait for ALL children
+  └─ continue_as_new(next state)   ← reset history, then batch N+1
+```
+
+The key is that the coordinator **waits for all children before resetting**, and
+carries only compact state (`cursor`, `batch_number`) across the `continue_as_new`
+boundary. Each restart begins with a fresh, small history.
+
+### Anti-Pattern: Unbounded Coordinator
+
+The following looks similar but never calls `continue_as_new`, so its history
+grows without bound and replays get progressively slower:
+
+```python
+# BAD: this coordinator never resets its history
+def coordinator(ctx, _):
+    while True:
+        item = yield ctx.wait_for_external_event("new-item")
+        yield ctx.call_sub_orchestrator(process_item_orchestrator, input=item)
+        # History grows by several events each iteration and is never reset
+```
+
+### Replay-safe logging
+
+The orchestrators log through `ctx.create_replay_safe_logger(logger)` so log lines
+are only emitted when the orchestrator is not replaying, avoiding duplicate logs.
+
+## Viewing in the Dashboard
+
+- **Emulator:** Navigate to http://localhost:8082 → select the "default" task hub
+- **Azure:** Navigate to your Scheduler resource in the Azure Portal → Task Hub → Dashboard URL
+
+Because the coordinator uses `continue_as_new`, you'll see a single coordinator
+instance whose history stays small across batches, alongside the short-lived child
+`process_item_orchestrator` instances.
+
+## Related Samples
+
+- [Eternal Orchestrations](../eternal-orchestrations/) - Single-orchestration `continue_as_new` loop
+- [Sub-orchestrations](../sub-orchestrations/) - Composing parent/child orchestrations
+- [Fan-out/Fan-in](../fan-out-fan-in/) - Parallel processing and aggregation
+
+## Learn More
+
+- [Eternal orchestrations](https://learn.microsoft.com/azure/azure-functions/durable/durable-functions-eternal-orchestrations)
+- [Durable Task Scheduler documentation](https://learn.microsoft.com/azure/azure-functions/durable/durable-task-scheduler/develop-with-durable-task-scheduler)

--- a/samples/durable-task-sdks/python/bounded-coordinator/client.py
+++ b/samples/durable-task-sdks/python/bounded-coordinator/client.py
@@ -1,0 +1,54 @@
+import asyncio
+import logging
+import os
+from azure.identity import DefaultAzureCredential
+from durabletask import client as durable_client
+from durabletask.azuremanaged.client import DurableTaskSchedulerClient
+
+# Configure logging
+logging.basicConfig(level=logging.INFO)
+logger = logging.getLogger(__name__)
+
+
+async def main():
+    """Main entry point that starts the bounded coordinator orchestration."""
+    logger.info("Starting Bounded Coordinator client...")
+
+    # Get environment variables for taskhub and endpoint with defaults
+    taskhub_name = os.getenv("TASKHUB", "default")
+    endpoint = os.getenv("ENDPOINT", "http://localhost:8080")
+
+    print(f"Using taskhub: {taskhub_name}")
+    print(f"Using endpoint: {endpoint}")
+
+    # Set credential to None for emulator, or DefaultAzureCredential for Azure
+    credential = None if endpoint == "http://localhost:8080" else DefaultAzureCredential()
+
+    client = DurableTaskSchedulerClient(
+        host_address=endpoint,
+        secure_channel=endpoint != "http://localhost:8080",
+        taskhub=taskhub_name,
+        token_credential=credential,
+    )
+
+    # Start the coordinator with no input; it initializes its own carry-forward state.
+    instance_id = client.schedule_new_orchestration("coordinator_orchestrator")
+    logger.info(f"Started coordinator_orchestrator, instance ID: {instance_id}")
+
+    # Wait for the coordinator to finish processing all batches. Each batch
+    # resets history via continue_as_new, but the instance ID stays the same.
+    state = client.wait_for_orchestration_completion(instance_id, timeout=120)
+
+    if state and state.runtime_status == durable_client.OrchestrationStatus.COMPLETED:
+        print(f"\nCompleted with status: {state.runtime_status}")
+        print(f"Result: {state.serialized_output}")
+    elif state:
+        print(f"\nOrchestration ended with status: {state.runtime_status}")
+        if state.failure_details:
+            print(f"Failure: {state.failure_details}")
+    else:
+        print("\nOrchestration did not complete within the timeout period")
+
+
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/samples/durable-task-sdks/python/bounded-coordinator/requirements.txt
+++ b/samples/durable-task-sdks/python/bounded-coordinator/requirements.txt
@@ -1,0 +1,2 @@
+durabletask-azuremanaged
+azure-identity

--- a/samples/durable-task-sdks/python/bounded-coordinator/worker.py
+++ b/samples/durable-task-sdks/python/bounded-coordinator/worker.py
@@ -1,0 +1,160 @@
+import asyncio
+import logging
+import os
+from azure.identity import DefaultAzureCredential
+from durabletask import task
+from durabletask.azuremanaged.worker import DurableTaskSchedulerWorker
+
+# Configure logging
+logging.basicConfig(level=logging.INFO)
+logger = logging.getLogger(__name__)
+
+# Tunables: how many batches the source yields, and how many items per batch.
+TOTAL_BATCHES = 3
+ITEMS_PER_BATCH = 5
+MAX_ITEMS = 50
+
+
+# Activity that returns a bounded batch of work items
+def get_next_batch(ctx: task.ActivityContext, input: dict) -> dict:
+    """Return a bounded batch of work items for the given cursor.
+
+    The batch number is derived deterministically from the cursor so the
+    activity is stateless and safe across retries / scale-out.
+    """
+    cursor = input.get("cursor")
+    max_items = input.get("max_items", MAX_ITEMS)
+
+    batch_number = 1 if cursor is None else int(cursor.split("-")[-1]) + 1
+
+    if batch_number > TOTAL_BATCHES:
+        return {"items": [], "next_cursor": None, "has_more": False}
+
+    count = min(ITEMS_PER_BATCH, max_items)
+    items = [
+        {
+            "id": f"item-{batch_number}-{i}",
+            "tenant_id": f"tenant-{i}",
+            "payload": f"data-{batch_number}-{i}",
+        }
+        for i in range(1, count + 1)
+    ]
+
+    return {
+        "items": items,
+        "next_cursor": f"cursor-{batch_number}",
+        "has_more": batch_number < TOTAL_BATCHES,
+    }
+
+
+# Activity that applies a change for a single work item
+def apply_change(ctx: task.ActivityContext, item: dict) -> str:
+    """Apply the change for a single work item."""
+    logger.info(f"Applying change for item {item['id']}, tenant {item['tenant_id']}")
+    return f"processed:{item['id']}"
+
+
+# Short-lived child orchestration that processes a single work item
+def process_item_orchestrator(ctx: task.OrchestrationContext, item: dict) -> str:
+    """Child orchestration that processes a single work item.
+
+    Completes quickly and does not accumulate history.
+    """
+    olog = ctx.create_replay_safe_logger(logger)
+    olog.info(f"Processing item {item['id']} for tenant {item['tenant_id']}")
+
+    result = yield ctx.call_activity(apply_change, input=item)
+    return result
+
+
+# Bounded coordinator orchestration
+def coordinator_orchestrator(ctx: task.OrchestrationContext, state: dict | None):
+    """Bounded coordinator that fans out child work, waits for all children,
+    then resets via continue_as_new.
+
+    This prevents unbounded history growth that can occur with long-lived
+    message-pump / coordinator orchestrations.
+    """
+    olog = ctx.create_replay_safe_logger(logger)
+
+    # Carry-forward state: a cursor into the work source and a batch counter.
+    state = state or {"cursor": None, "batch_number": 0}
+    cursor = state["cursor"]
+    batch_number = state["batch_number"]
+
+    olog.info(f"Coordinator batch {batch_number}, cursor={cursor or '(start)'}")
+
+    # Step 1: Read a BOUNDED batch of work items.
+    batch = yield ctx.call_activity(
+        get_next_batch, input={"cursor": cursor, "max_items": MAX_ITEMS}
+    )
+
+    if not batch["items"]:
+        olog.info("No more items to process. Coordinator completing.")
+        return {"total_batches": batch_number, "completed": True}
+
+    # Step 2: Fan out child sub-orchestrations for this batch.
+    olog.info(f"Processing batch of {len(batch['items'])} items")
+    child_tasks = [
+        ctx.call_sub_orchestrator(process_item_orchestrator, input=item)
+        for item in batch["items"]
+    ]
+
+    # Step 3: Wait for ALL children to complete before resetting.
+    # This is critical - never call continue_as_new while children are still running.
+    yield task.when_all(child_tasks)
+
+    olog.info(f"Batch {batch_number + 1} complete. {len(batch['items'])} items processed.")
+
+    # Step 4: continue_as_new with compact carry-forward state. This resets the
+    # orchestration history, preventing unbounded growth.
+    if batch["has_more"]:
+        ctx.continue_as_new({
+            "cursor": batch["next_cursor"],
+            "batch_number": batch_number + 1,
+        })
+        return  # unreachable after continue_as_new
+
+    return {"total_batches": batch_number + 1, "completed": True}
+
+
+async def main():
+    """Main entry point for the worker process."""
+    logger.info("Starting Bounded Coordinator pattern worker...")
+
+    # Get environment variables for taskhub and endpoint with defaults
+    taskhub_name = os.getenv("TASKHUB", "default")
+    endpoint = os.getenv("ENDPOINT", "http://localhost:8080")
+
+    print(f"Using taskhub: {taskhub_name}")
+    print(f"Using endpoint: {endpoint}")
+
+    # Set credential to None for emulator, or DefaultAzureCredential for Azure
+    credential = None if endpoint == "http://localhost:8080" else DefaultAzureCredential()
+
+    with DurableTaskSchedulerWorker(
+        host_address=endpoint,
+        secure_channel=endpoint != "http://localhost:8080",
+        taskhub=taskhub_name,
+        token_credential=credential,
+    ) as worker:
+
+        # Register activities and orchestrators
+        worker.add_activity(get_next_batch)
+        worker.add_activity(apply_change)
+        worker.add_orchestrator(process_item_orchestrator)
+        worker.add_orchestrator(coordinator_orchestrator)
+
+        # Start the worker
+        worker.start()
+
+        try:
+            while True:
+                await asyncio.sleep(1)
+        except KeyboardInterrupt:
+            logger.info("Worker shutdown initiated")
+
+    logger.info("Worker stopped")
+
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/samples/durable-task-sdks/python/entities/README.md
+++ b/samples/durable-task-sdks/python/entities/README.md
@@ -8,7 +8,8 @@ In this sample:
 1. A counter entity is defined that supports `add`, `subtract`, `get`, and `reset` operations
 2. The client signals the entity directly to modify its state
 3. Orchestrations interact with entities using `signal_entity` and `call_entity`
-4. Entity state is automatically persisted and survives restarts
+4. A **delayed entity signal** schedules a `reset` operation to be delivered at a future time
+5. Entity state is automatically persisted and survives restarts
 
 This pattern is useful for:
 - Building aggregators and accumulators
@@ -167,6 +168,28 @@ Entities support two types of operations:
    value = yield ctx.call_entity(entity=entity_id, operation="get")
    ```
 
+### Delayed (Scheduled) Signals
+
+A signal can be scheduled to be delivered at a future time by passing
+`signal_time`. This is useful for reminders, timeouts, or having an entity wake
+itself up later. Compute the time from the orchestrator's deterministic clock:
+
+```python
+from datetime import timedelta
+
+reset_time = ctx.current_utc_datetime + timedelta(seconds=5)
+ctx.signal_entity(
+    entity_id=entity_id,
+    operation_name="reset",
+    signal_time=reset_time,
+)
+```
+
+The orchestrator continues immediately; the `reset` operation is delivered to the
+entity only after `signal_time` is reached. The same `signal_time` parameter is
+available on `EntityContext.signal_entity`, so an entity can schedule a delayed
+signal to itself or another entity.
+
 ### Client Operations
 
 Entities can also be signaled directly from clients:
@@ -247,7 +270,7 @@ Signaling entity 'my-counter' to add 100
 Signaling entity 'my-counter' to subtract 25
 === Orchestration-based Entity Operations ===
 Scheduling orchestration #1 for entity 'my-counter-orch-1'
-Orchestration completed successfully with result: "Counter 'my-counter-orch-1' final value: 12"
+Orchestration completed successfully with result: "Counter 'my-counter-orch-1': value before delayed reset=12, value after delayed reset=0"
 ```
 
 ## Reviewing the Orchestration in the Durable Task Scheduler Dashboard

--- a/samples/durable-task-sdks/python/entities/worker.py
+++ b/samples/durable-task-sdks/python/entities/worker.py
@@ -1,6 +1,7 @@
 import asyncio
 import logging
 import os
+from datetime import timedelta
 from azure.identity import DefaultAzureCredential, ManagedIdentityCredential
 from azure.core.exceptions import ClientAuthenticationError
 from durabletask import task, entities
@@ -37,26 +38,43 @@ def counter(ctx: entities.EntityContext, input: int):
 
 # Orchestrator that interacts with the counter entity
 def counter_workflow(ctx: task.OrchestrationContext, entity_key: str):
-    """Orchestration that demonstrates entity interactions.
-    
+    """Orchestration that demonstrates entity interactions, including a
+    delayed (scheduled) entity signal.
+
     This orchestration:
     1. Creates/accesses a counter entity
     2. Adds values to the counter
-    3. Gets the current value
-    4. Subtracts a value
-    5. Returns the final count
+    3. Schedules a delayed `reset` signal to fire a few seconds in the future
+    4. Reads the value before the delayed reset fires
+    5. Waits past the scheduled time, then reads the value again
+    6. Returns both values to show the delayed signal took effect
     """
     entity_id = entities.EntityInstanceId("counter", entity_key)
-    
+
     # Signal entity operations (fire-and-forget)
     ctx.signal_entity(entity_id=entity_id, operation_name="add", input=10)
     ctx.signal_entity(entity_id=entity_id, operation_name="add", input=5)
     ctx.signal_entity(entity_id=entity_id, operation_name="subtract", input=3)
-    
-    # Call entity and wait for result (note: call_entity uses 'entity' and 'operation' params)
-    value = yield ctx.call_entity(entity=entity_id, operation="get")
-    
-    return f"Counter '{entity_key}' final value: {value}"
+
+    # Schedule a DELAYED signal: the `reset` operation is delivered at a future
+    # time via `signal_time`, rather than as soon as possible. Use the
+    # orchestrator's deterministic clock (`current_utc_datetime`) to compute it.
+    reset_time = ctx.current_utc_datetime + timedelta(seconds=5)
+    ctx.signal_entity(
+        entity_id=entity_id,
+        operation_name="reset",
+        signal_time=reset_time,
+    )
+
+    # Read the value before the delayed reset is delivered (expect 10 + 5 - 3 = 12)
+    value_before = yield ctx.call_entity(entity=entity_id, operation="get")
+
+    # Wait until after the scheduled reset time, then read again (expect 0)
+    yield ctx.create_timer(ctx.current_utc_datetime + timedelta(seconds=7))
+    value_after = yield ctx.call_entity(entity=entity_id, operation="get")
+
+    return (f"Counter '{entity_key}': value before delayed reset={value_before}, "
+            f"value after delayed reset={value_after}")
 
 
 # Activity to log entity state

--- a/samples/durable-task-sdks/python/fan-out-fan-in/README.md
+++ b/samples/durable-task-sdks/python/fan-out-fan-in/README.md
@@ -17,6 +17,23 @@ This pattern is useful for:
 - Running operations in parallel that don't depend on each other
 - Aggregating results from multiple parallel operations
 
+### Replay-safe logging
+
+Orchestrators replay their code repeatedly as the workflow makes progress. Logging
+with the raw module logger inside an orchestrator re-emits every line on each
+replay, producing confusing duplicate logs. This sample wraps the logger with a
+**replay-safe logger** that only emits when the orchestrator is *not* replaying:
+
+```python
+def fan_out_fan_in_orchestrator(ctx, work_items: list) -> dict:
+    olog = ctx.create_replay_safe_logger(logger)
+    olog.info(f"Starting fan out/fan in orchestration with {len(work_items)} items")
+    ...
+```
+
+Use `ctx.create_replay_safe_logger(...)` for any logging done directly inside an
+orchestrator. Activities run only once, so they can use a normal logger.
+
 ## Prerequisites
 
 1. [Python 3.9+](https://www.python.org/downloads/)

--- a/samples/durable-task-sdks/python/fan-out-fan-in/worker.py
+++ b/samples/durable-task-sdks/python/fan-out-fan-in/worker.py
@@ -44,7 +44,12 @@ def fan_out_fan_in_orchestrator(ctx, work_items: list) -> dict:
     This orchestrator processes multiple items in parallel (fan out) and then
     aggregates the results once all parallel executions complete (fan in).
     """
-    logger.info(f"Starting fan out/fan in orchestration with {len(work_items)} items")
+    # Orchestrators replay their code many times as the workflow progresses.
+    # Logging with the raw module logger would re-emit every line on each
+    # replay, producing confusing duplicate logs. A replay-safe logger wraps
+    # the logger and only emits when the orchestrator is NOT replaying.
+    olog = ctx.create_replay_safe_logger(logger)
+    olog.info(f"Starting fan out/fan in orchestration with {len(work_items)} items")
     
     # Fan out: Create a task for each work item
     parallel_tasks = []
@@ -52,11 +57,11 @@ def fan_out_fan_in_orchestrator(ctx, work_items: list) -> dict:
         parallel_tasks.append(ctx.call_activity("process_work_item", input=item))
     
     # Wait for all tasks to complete
-    logger.info(f"Waiting for {len(parallel_tasks)} parallel tasks to complete")
+    olog.info(f"Waiting for {len(parallel_tasks)} parallel tasks to complete")
     results = yield task.when_all(parallel_tasks)
     
     # Fan in: Aggregate all the results
-    logger.info("All parallel tasks completed, aggregating results")
+    olog.info("All parallel tasks completed, aggregating results")
     final_result = yield ctx.call_activity("aggregate_results", input=results)
     
     return final_result

--- a/samples/durable-task-sdks/python/function-chaining/README.md
+++ b/samples/durable-task-sdks/python/function-chaining/README.md
@@ -10,10 +10,48 @@ In this sample:
 3. That result is passed to the `finalize_response` activity
 4. The final result is returned to the client
 
+Activities exchange a typed `Greeting` dataclass rather than a plain string. This
+showcases the SDK's **type-aware serialization**: the built-in converter
+serializes the dataclass and reconstructs it as a typed `Greeting` at each
+boundary where the target type is known - from an activity parameter annotation
+(`greeting: Greeting`) or a `return_type=Greeting` hint on `call_activity`.
+
 This pattern is useful for:
 - Creating sequential workflows where steps must execute in order
 - Passing data between steps with data transformations at each step
 - Building pipelines where each activity adds value to the result
+- Passing rich, strongly-typed objects between activities and orchestrators
+
+### Type-aware serialization
+
+The payload exchanged between steps is a dataclass:
+
+```python
+from dataclasses import dataclass
+
+@dataclass
+class Greeting:
+    recipient: str
+    message: str
+```
+
+Because the activity parameters are annotated with `Greeting` and the
+orchestrator passes `return_type=Greeting`, the value stays strongly typed end to
+end - no manual dict handling required:
+
+```python
+def process_greeting(ctx, greeting: Greeting) -> Greeting:
+    # `greeting` is a fully-typed Greeting, not a raw dict
+    return Greeting(greeting.recipient, f"{greeting.message} How are you today?")
+
+# In the orchestrator:
+greeting = yield ctx.call_activity(process_greeting, input=greeting, return_type=Greeting)
+```
+
+> **Note:** The built-in converter reconstructs a dataclass when it is the
+> top-level target type. A model nested inside a generic (for example
+> `return_type=list[Greeting]`) falls back to raw dicts unless you supply a
+> custom `DataConverter`.
 
 ## Prerequisites
 

--- a/samples/durable-task-sdks/python/function-chaining/worker.py
+++ b/samples/durable-task-sdks/python/function-chaining/worker.py
@@ -1,6 +1,7 @@
 import asyncio
 import logging
 import os
+from dataclasses import dataclass
 from azure.identity import DefaultAzureCredential, ManagedIdentityCredential
 from azure.core.exceptions import ClientAuthenticationError
 from durabletask.azuremanaged.worker import DurableTaskSchedulerWorker
@@ -9,37 +10,54 @@ from durabletask.azuremanaged.worker import DurableTaskSchedulerWorker
 logging.basicConfig(level=logging.INFO)
 logger = logging.getLogger(__name__)
 
+
+# A typed payload passed between activities. The SDK's built-in converter
+# understands dataclasses, so this object is serialized on the way out and
+# reconstructed as a typed `Greeting` (not a raw dict) at each boundary where
+# the target type is known - either from an activity's parameter annotation or
+# from a `return_type=` hint on `call_activity`.
+@dataclass
+class Greeting:
+    recipient: str
+    message: str
+
+
 # Activity functions
-def say_hello(ctx, name: str) -> str:
-    """First activity that greets the user."""
+def say_hello(ctx, name: str) -> Greeting:
+    """First activity that builds a typed greeting."""
     logger.info(f"Activity say_hello called with name: {name}")
-    return f"Hello {name}!"
+    return Greeting(recipient=name, message=f"Hello {name}!")
 
-def process_greeting(ctx, greeting: str) -> str:
-    """Second activity that processes the greeting."""
-    logger.info(f"Activity process_greeting called with greeting: {greeting}")
-    return f"{greeting} How are you today?"
+def process_greeting(ctx, greeting: Greeting) -> Greeting:
+    """Second activity that processes the greeting.
 
-def finalize_response(ctx, response: str) -> str:
+    `greeting` arrives as a fully-typed `Greeting` instance - reconstructed
+    from the `greeting: Greeting` parameter annotation - so attribute access
+    works directly without manual dict handling.
+    """
+    logger.info(f"Activity process_greeting called for: {greeting.recipient}")
+    return Greeting(greeting.recipient, f"{greeting.message} How are you today?")
+
+def finalize_response(ctx, greeting: Greeting) -> Greeting:
     """Third activity that finalizes the response."""
-    logger.info(f"Activity finalize_response called with response: {response}")
-    return f"{response} I hope you're doing well!"
+    logger.info(f"Activity finalize_response called for: {greeting.recipient}")
+    return Greeting(greeting.recipient, f"{greeting.message} I hope you're doing well!")
 
 # Orchestrator function
 def function_chaining_orchestrator(ctx, name: str) -> str:
-    """Orchestrator that demonstrates function chaining pattern."""
-    logger.info(f"Starting function chaining orchestration for {name}")
-    
-    # Call first activity - passing input directly without named parameter
-    greeting = yield ctx.call_activity('say_hello', input=name)
-    
-    # Call second activity with the result from first activity
-    processed_greeting = yield ctx.call_activity('process_greeting', input=greeting)
-    
-    # Call third activity with the result from second activity
-    final_response = yield ctx.call_activity('finalize_response', input=processed_greeting)
-    
-    return final_response
+    """Orchestrator that demonstrates function chaining with typed payloads."""
+    # Use a replay-safe logger so this line is not re-emitted on every replay.
+    olog = ctx.create_replay_safe_logger(logger)
+    olog.info(f"Starting function chaining orchestration for {name}")
+
+    # Each call passes a typed `Greeting` between activities. `return_type=Greeting`
+    # asks the SDK to reconstruct the activity result as a `Greeting` here in the
+    # orchestrator too, so the value stays strongly typed end to end.
+    greeting = yield ctx.call_activity(say_hello, input=name, return_type=Greeting)
+    greeting = yield ctx.call_activity(process_greeting, input=greeting, return_type=Greeting)
+    greeting = yield ctx.call_activity(finalize_response, input=greeting, return_type=Greeting)
+
+    return greeting.message
 
 async def main():
     """Main entry point for the worker process."""

--- a/samples/durable-task-sdks/python/history-export/README.md
+++ b/samples/durable-task-sdks/python/history-export/README.md
@@ -1,0 +1,250 @@
+# History Export
+
+Python | Durable Task SDK
+
+## Description of the Sample
+
+This sample demonstrates exporting the **event history of terminal orchestrations** to Azure Blob Storage using the `durabletask.extensions.history_export` extension with the Python SDK. An export job scans a time window of completed orchestrations and writes each instance's history to a blob container as gzipped JSONL.
+
+This is the Python counterpart to the .NET [ExportHistoryWebApp](../../dotnet/ExportHistoryWebApp/) sample.
+
+In this sample:
+1. Five small orchestrations are scheduled and run to completion to populate history
+2. An export job is created for the recent time window
+3. The job is polled until it reaches a terminal status, then the result summary is printed
+
+This pattern is useful for:
+- Archiving orchestration history for compliance or auditing
+- Moving completed-instance history out of the scheduler for long-term retention
+- Feeding orchestration history into downstream analytics pipelines
+
+## Prerequisites
+
+1. [Python 3.10+](https://www.python.org/downloads/)
+2. [Docker](https://www.docker.com/products/docker-desktop/) (for running the emulator)
+3. An Azure Storage destination. For local development use [Azurite](https://learn.microsoft.com/azure/storage/common/storage-use-azurite), the Azure Storage emulator:
+   ```bash
+   npm install -g azurite
+   azurite --silent --blobPort 10000
+   ```
+4. [Azure CLI](https://docs.microsoft.com/cli/azure/install-azure-cli) (if using a deployed Durable Task Scheduler)
+
+## Configuring Durable Task Scheduler
+
+There are two ways to run this sample locally:
+
+### Using the Emulator (Recommended)
+
+The emulator simulates a scheduler and taskhub in a Docker container, making it ideal for development and learning.
+
+1. Pull the Docker Image for the Emulator:
+   ```bash
+   docker pull mcr.microsoft.com/dts/dts-emulator:latest
+   ```
+
+2. Run the Emulator:
+   ```bash
+   docker run --name dtsemulator -d -p 8080:8080 -p 8082:8082 mcr.microsoft.com/dts/dts-emulator:latest
+   ```
+
+Wait a few seconds for the container to be ready.
+
+Note: The example code automatically uses the default emulator settings (endpoint: `http://localhost:8080`, taskhub: `default`). You don't need to set any environment variables for the scheduler.
+
+### Using a Deployed Scheduler and Taskhub in Azure
+
+Local development with a deployed scheduler:
+
+1. Install the durable task scheduler CLI extension:
+
+    ```bash
+    az upgrade
+    az extension add --name durabletask --allow-preview true
+    ```
+
+2. Create a resource group in a region where the Durable Task Scheduler is available:
+
+    ```bash
+    az provider show --namespace Microsoft.DurableTask --query "resourceTypes[?resourceType=='schedulers'].locations | [0]" --out table
+    ```
+
+    ```bash
+    az group create --name my-resource-group --location <location>
+    ```
+
+3. Create a durable task scheduler resource:
+
+    ```bash
+    az durabletask scheduler create \
+        --resource-group my-resource-group \
+        --name my-scheduler \
+        --ip-allowlist '["0.0.0.0/0"]' \
+        --sku-name "Dedicated" \
+        --sku-capacity 1 \
+        --tags "{'myattribute':'myvalue'}"
+    ```
+
+4. Create a task hub within the scheduler resource:
+
+    ```bash
+    az durabletask taskhub create \
+        --resource-group my-resource-group \
+        --scheduler-name my-scheduler \
+        --name "my-taskhub"
+    ```
+
+5. Grant the current user permission to connect to the `my-taskhub` task hub:
+
+    ```bash
+    subscriptionId=$(az account show --query "id" -o tsv)
+    loggedInUser=$(az account show --query "user.name" -o tsv)
+
+    az role assignment create \
+        --assignee $loggedInUser \
+        --role "Durable Task Data Contributor" \
+        --scope "/subscriptions/$subscriptionId/resourceGroups/my-resource-group/providers/Microsoft.DurableTask/schedulers/my-scheduler/taskHubs/my-taskhub"
+    ```
+
+## Configuring the Storage Destination
+
+The export destination is configured with two environment variables (both optional):
+
+- `STORAGE_CONNECTION_STRING` - Azure Storage connection string for the export destination. Defaults to `UseDevelopmentStorage=true` (Azurite).
+- `EXPORT_CONTAINER` - Destination blob container name. Defaults to `history-export-sample`.
+
+To export to a real Azure Storage account:
+```bash
+export STORAGE_CONNECTION_STRING="DefaultEndpointsProtocol=https;AccountName=...;AccountKey=...;EndpointSuffix=core.windows.net"
+export EXPORT_CONTAINER="my-history-exports"
+```
+
+## How to Run the Sample
+
+Once you have set up the emulator (or deployed scheduler) and Azurite, follow these steps:
+
+1. First, activate your Python virtual environment (if you're using one):
+   ```bash
+   python -m venv venv
+   source venv/bin/activate  # On Windows, use: venv\Scripts\activate
+   ```
+
+2. If you're using a deployed scheduler, set environment variables:
+   ```bash
+   export ENDPOINT=$(az durabletask scheduler show \
+       --resource-group my-resource-group \
+       --name my-scheduler \
+       --query "properties.endpoint" \
+       --output tsv)
+
+   export TASKHUB="my-taskhub"
+   ```
+
+3. Install the required packages:
+   ```bash
+   pip install -r requirements.txt
+   ```
+
+4. Start the worker in a terminal:
+   ```bash
+   python worker.py
+   ```
+
+5. In a new terminal (with the virtual environment activated if applicable), run the client:
+   > **Note:** Remember to set the environment variables again if you're using a deployed scheduler. Set the same `STORAGE_CONNECTION_STRING` / `EXPORT_CONTAINER` values for both the worker and the client.
+
+   ```bash
+   python client.py
+   ```
+
+## Expected Output
+
+### Client Output
+```
+=== Step 1: Seed sample orchestrations ===
+  Completed: <id-1> -> 1
+  Completed: <id-2> -> 4
+  Completed: <id-3> -> 9
+  Completed: <id-4> -> 16
+  Completed: <id-5> -> 25
+
+=== Step 2: Create export job ===
+  job_id: <job-id>
+  orchestrator_instance_id: export-job-<job-id>
+
+=== Step 3: Wait for export job ===
+  status:             completed
+  scanned_instances:  5
+  exported_instances: 5
+  failed_instances:   0
+
+Done!
+```
+
+After running, the gzipped JSONL history files appear in the `history-export-sample` container under the `sample-run/` prefix.
+
+## Code Walkthrough
+
+### Configuring the writer (worker and client)
+
+The Azure Blob writer routes exported history to blob storage. The worker's
+export activities perform the actual writes:
+
+```python
+from durabletask.extensions.history_export.azure_blob import (
+    AzureBlobHistoryExportWriter,
+    AzureBlobHistoryExportWriterOptions,
+)
+
+writer = AzureBlobHistoryExportWriter(
+    AzureBlobHistoryExportWriterOptions(
+        container_name=CONTAINER_NAME,
+        connection_string=STORAGE_CONNECTION_STRING,
+    )
+)
+```
+
+### Registering the export feature on the worker
+
+```python
+from durabletask.extensions.history_export import ExportHistoryClient
+
+export_client = ExportHistoryClient(client, writer)
+export_client.register_worker(worker)  # entity + activities + orchestrator
+```
+
+### Creating and awaiting an export job (client)
+
+```python
+from durabletask.extensions.history_export import (
+    ExportDestination, ExportFormat, ExportFormatKind,
+    ExportJobCreationOptions, ExportMode,
+)
+
+desc = export_client.create_job(ExportJobCreationOptions(
+    mode=ExportMode.BATCH,
+    completed_time_from=now - timedelta(hours=1),
+    completed_time_to=now + timedelta(hours=1),
+    destination=ExportDestination(container=CONTAINER_NAME, prefix="sample-run"),
+    format=ExportFormat(kind=ExportFormatKind.JSONL_GZIP),
+    max_instances_per_batch=10,
+))
+
+final = export_client.wait_for_job(desc.job_id, timeout=120, poll_interval=0.5)
+```
+
+## Viewing in the Dashboard
+
+- **Emulator:** Navigate to http://localhost:8082 → select the "default" task hub
+- **Azure:** Navigate to your Scheduler resource in the Azure Portal → Task Hub → Dashboard URL
+
+The export job itself runs as an orchestration (`export-job-<job-id>`) backed by a durable entity, so it is visible in the dashboard alongside the seeded sample orchestrations.
+
+## Related Samples
+
+- [Large Payload](../large-payload/) - Externalizing large payloads to Azure Blob Storage
+- [Orchestration Management](../orchestration-management/) - Restart, query, and purge orchestrations
+- [Entities](../entities/) - The durable entity feature that backs the export job
+
+## Learn More
+
+- [Durable Task Scheduler documentation](https://learn.microsoft.com/azure/azure-functions/durable/durable-task-scheduler/develop-with-durable-task-scheduler)

--- a/samples/durable-task-sdks/python/history-export/client.py
+++ b/samples/durable-task-sdks/python/history-export/client.py
@@ -1,0 +1,113 @@
+import asyncio
+import logging
+import os
+import time
+from datetime import datetime, timedelta, timezone
+from azure.identity import DefaultAzureCredential
+from durabletask import client as durable_client
+from durabletask.azuremanaged.client import DurableTaskSchedulerClient
+from durabletask.extensions.history_export import (
+    ExportDestination,
+    ExportFormat,
+    ExportFormatKind,
+    ExportHistoryClient,
+    ExportJobCreationOptions,
+    ExportMode,
+)
+from durabletask.extensions.history_export.azure_blob import (
+    AzureBlobHistoryExportWriter,
+    AzureBlobHistoryExportWriterOptions,
+)
+
+# Configure logging
+logging.basicConfig(level=logging.INFO)
+logger = logging.getLogger(__name__)
+
+CONTAINER_NAME = os.getenv("EXPORT_CONTAINER", "history-export-sample")
+STORAGE_CONNECTION_STRING = os.getenv("STORAGE_CONNECTION_STRING", "UseDevelopmentStorage=true")
+
+
+async def main():
+    """Main entry point demonstrating orchestration history export."""
+    logger.info("Starting History Export client...")
+
+    # Get environment variables for taskhub and endpoint with defaults
+    taskhub_name = os.getenv("TASKHUB", "default")
+    endpoint = os.getenv("ENDPOINT", "http://localhost:8080")
+
+    print(f"Using taskhub: {taskhub_name}")
+    print(f"Using endpoint: {endpoint}")
+    print(f"Using container: {CONTAINER_NAME}")
+
+    # Set credential to None for emulator, or DefaultAzureCredential for Azure
+    credential = None if endpoint == "http://localhost:8080" else DefaultAzureCredential()
+
+    client = DurableTaskSchedulerClient(
+        host_address=endpoint,
+        secure_channel=endpoint != "http://localhost:8080",
+        taskhub=taskhub_name,
+        token_credential=credential,
+    )
+
+    # The client needs an ExportHistoryClient to create and poll export jobs.
+    # The writer here mirrors the one configured on the worker; the worker's
+    # activities perform the actual blob writes.
+    writer = AzureBlobHistoryExportWriter(
+        AzureBlobHistoryExportWriterOptions(
+            container_name=CONTAINER_NAME,
+            connection_string=STORAGE_CONNECTION_STRING,
+        )
+    )
+
+    try:
+        export_client = ExportHistoryClient(client, writer)
+
+        # =====================================================================
+        # 1. Seed some terminal orchestrations to export
+        # =====================================================================
+        print("\n=== Step 1: Seed sample orchestrations ===")
+        for n in range(1, 6):
+            instance_id = client.schedule_new_orchestration("sample_orchestrator", input=n)
+            state = client.wait_for_orchestration_completion(instance_id, timeout=30)
+            if state and state.runtime_status == durable_client.OrchestrationStatus.COMPLETED:
+                print(f"  Completed: {instance_id} -> {state.serialized_output}")
+        # Give the scheduler a moment to finalize terminal history.
+        time.sleep(1)
+
+        # =====================================================================
+        # 2. Create an export job for the recent time window
+        # =====================================================================
+        print("\n=== Step 2: Create export job ===")
+        now = datetime.now(timezone.utc)
+        desc = export_client.create_job(
+            ExportJobCreationOptions(
+                mode=ExportMode.BATCH,
+                completed_time_from=now - timedelta(hours=1),
+                completed_time_to=now + timedelta(hours=1),
+                destination=ExportDestination(container=CONTAINER_NAME, prefix="sample-run"),
+                format=ExportFormat(kind=ExportFormatKind.JSONL_GZIP),
+                max_instances_per_batch=10,
+            )
+        )
+        print(f"  job_id: {desc.job_id}")
+        print(f"  orchestrator_instance_id: {desc.orchestrator_instance_id}")
+
+        # =====================================================================
+        # 3. Wait for the export job to finish and print the result
+        # =====================================================================
+        print("\n=== Step 3: Wait for export job ===")
+        final = export_client.wait_for_job(desc.job_id, timeout=120, poll_interval=0.5)
+        print(f"  status:             {final.status.value}")
+        print(f"  scanned_instances:  {final.scanned_instances}")
+        print(f"  exported_instances: {final.exported_instances}")
+        print(f"  failed_instances:   {final.failed_instances}")
+        if final.last_error:
+            print(f"  last_error:         {final.last_error}")
+
+        print("\nDone!")
+    finally:
+        writer.close()
+
+
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/samples/durable-task-sdks/python/history-export/requirements.txt
+++ b/samples/durable-task-sdks/python/history-export/requirements.txt
@@ -1,0 +1,3 @@
+durabletask-azuremanaged
+durabletask[history-export-azure]
+azure-identity

--- a/samples/durable-task-sdks/python/history-export/worker.py
+++ b/samples/durable-task-sdks/python/history-export/worker.py
@@ -1,0 +1,101 @@
+import asyncio
+import logging
+import os
+from azure.identity import DefaultAzureCredential
+from durabletask import task
+from durabletask.azuremanaged.client import DurableTaskSchedulerClient
+from durabletask.azuremanaged.worker import DurableTaskSchedulerWorker
+from durabletask.extensions.history_export import ExportHistoryClient
+from durabletask.extensions.history_export.azure_blob import (
+    AzureBlobHistoryExportWriter,
+    AzureBlobHistoryExportWriterOptions,
+)
+
+# Configure logging
+logging.basicConfig(level=logging.INFO)
+logger = logging.getLogger(__name__)
+
+# Destination container and storage connection string. Defaults target Azurite,
+# the local Azure Storage emulator. Set STORAGE_CONNECTION_STRING to point at a
+# real Azure Storage account instead.
+CONTAINER_NAME = os.getenv("EXPORT_CONTAINER", "history-export-sample")
+STORAGE_CONNECTION_STRING = os.getenv("STORAGE_CONNECTION_STRING", "UseDevelopmentStorage=true")
+
+
+# Sample workload that produces orchestration history to export
+def square(ctx: task.ActivityContext, n: int) -> int:
+    """Activity that squares a number."""
+    logger.info(f"Squaring {n}")
+    return n * n
+
+
+def sample_orchestrator(ctx: task.OrchestrationContext, n: int):
+    """Simple orchestration whose history will be exported."""
+    result = yield ctx.call_activity(square, input=n)
+    return result
+
+
+async def main():
+    """Main entry point for the worker process."""
+    logger.info("Starting History Export pattern worker...")
+
+    # Get environment variables for taskhub and endpoint with defaults
+    taskhub_name = os.getenv("TASKHUB", "default")
+    endpoint = os.getenv("ENDPOINT", "http://localhost:8080")
+
+    print(f"Using taskhub: {taskhub_name}")
+    print(f"Using endpoint: {endpoint}")
+    print(f"Using container: {CONTAINER_NAME}")
+
+    # Set credential to None for emulator, or DefaultAzureCredential for Azure
+    credential = None if endpoint == "http://localhost:8080" else DefaultAzureCredential()
+
+    client = DurableTaskSchedulerClient(
+        host_address=endpoint,
+        secure_channel=endpoint != "http://localhost:8080",
+        taskhub=taskhub_name,
+        token_credential=credential,
+    )
+
+    # The Azure Blob writer is what the export activities use to write each
+    # instance's history as gzipped JSONL to the destination container.
+    writer = AzureBlobHistoryExportWriter(
+        AzureBlobHistoryExportWriterOptions(
+            container_name=CONTAINER_NAME,
+            connection_string=STORAGE_CONNECTION_STRING,
+        )
+    )
+
+    try:
+        export_client = ExportHistoryClient(client, writer)
+
+        with DurableTaskSchedulerWorker(
+            host_address=endpoint,
+            secure_channel=endpoint != "http://localhost:8080",
+            taskhub=taskhub_name,
+            token_credential=credential,
+        ) as worker:
+
+            # Register the sample workload
+            worker.add_activity(square)
+            worker.add_orchestrator(sample_orchestrator)
+
+            # Register the export-job entity, activities, and orchestrator that
+            # perform the actual history export. This binds the writer above so
+            # the export activities can write to blob storage.
+            export_client.register_worker(worker)
+
+            worker.start()
+
+            try:
+                while True:
+                    await asyncio.sleep(1)
+            except KeyboardInterrupt:
+                logger.info("Worker shutdown initiated")
+    finally:
+        writer.close()
+
+    logger.info("Worker stopped")
+
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/samples/durable-task-sdks/python/human-interaction/worker.py
+++ b/samples/durable-task-sdks/python/human-interaction/worker.py
@@ -63,7 +63,9 @@ def human_interaction_orchestrator(ctx, input_data: dict) -> dict:
     item = input_data.get("item")
     timeout_hours = input_data.get("timeout_hours", 24)
     
-    logger.info(f"Starting human interaction orchestration for request {request_id}")
+    # Use a replay-safe logger so these lines are not re-emitted on every replay.
+    olog = ctx.create_replay_safe_logger(logger)
+    olog.info(f"Starting human interaction orchestration for request {request_id}")
     
     # Submit the approval request
     request_data = {
@@ -96,7 +98,7 @@ def human_interaction_orchestrator(ctx, input_data: dict) -> dict:
         # Human responded in time
         # Get the event result - in the new SDK, we need to access the output of the task properly
         approval_data = yield approval_task
-        logger.info(f"Received approval response for request {request_id}")
+        olog.info(f"Received approval response for request {request_id}")
         
         # Process the approval
         result = yield ctx.call_activity("process_approval", input={
@@ -106,7 +108,7 @@ def human_interaction_orchestrator(ctx, input_data: dict) -> dict:
         })
     else:
         # Timeout occurred
-        logger.info(f"Request {request_id} timed out waiting for approval")
+        olog.info(f"Request {request_id} timed out waiting for approval")
         result = {
             "request_id": request_id,
             "status": "Timeout",

--- a/samples/durable-task-sdks/python/monitoring/worker.py
+++ b/samples/durable-task-sdks/python/monitoring/worker.py
@@ -48,9 +48,12 @@ def monitoring_job_orchestrator(ctx, job_data: dict) -> dict:
     polling_interval = job_data.get("polling_interval_seconds", 5)
     timeout = job_data.get("timeout_seconds", 30)
     
-    logger.info(f"Starting monitoring orchestration for job {job_id}")
-    logger.info(f"Polling interval: {polling_interval} seconds")
-    logger.info(f"Timeout: {timeout} seconds")
+    # Use a replay-safe logger so these lines are not re-emitted on every replay
+    # (this orchestrator loops and replays many times).
+    olog = ctx.create_replay_safe_logger(logger)
+    olog.info(f"Starting monitoring orchestration for job {job_id}")
+    olog.info(f"Polling interval: {polling_interval} seconds")
+    olog.info(f"Timeout: {timeout} seconds")
     
     # Record the start time
     start_time = ctx.current_utc_datetime
@@ -73,13 +76,13 @@ def monitoring_job_orchestrator(ctx, job_data: dict) -> dict:
         ctx.set_custom_status(job_status)
         
         if job_status["status"] == "Completed":
-            logger.info(f"Job {job_id} completed after {job_status['check_count']} checks")
+            olog.info(f"Job {job_id} completed after {job_status['check_count']} checks")
             break
         
         # Check if we've hit the timeout
         current_time = ctx.current_utc_datetime
         if current_time >= expiration_time:
-            logger.info(f"Monitoring for job {job_id} timed out after {timeout} seconds")
+            olog.info(f"Monitoring for job {job_id} timed out after {timeout} seconds")
             job_status["status"] = "Timeout"
             break
         
@@ -91,7 +94,7 @@ def monitoring_job_orchestrator(ctx, job_data: dict) -> dict:
             next_check_time = expiration_time
         
         # Schedule the next check
-        logger.info(f"Waiting {polling_interval} seconds before next check of job {job_id}")
+        olog.info(f"Waiting {polling_interval} seconds before next check of job {job_id}")
         yield ctx.create_timer(next_check_time)
     
     # Return the final status

--- a/samples/durable-task-sdks/python/saga/worker.py
+++ b/samples/durable-task-sdks/python/saga/worker.py
@@ -120,7 +120,8 @@ def travel_booking_saga(ctx, input: dict):
 
     except Exception as e:
         # Compensation: undo completed bookings in reverse order
-        logger.info(f"Booking failed: {e}. Starting compensation...")
+        olog = ctx.create_replay_safe_logger(logger)
+        olog.info(f"Booking failed: {e}. Starting compensation...")
         compensations = []
 
         for booking, cancel_activity in reversed(completed_bookings):

--- a/samples/durable-task-sdks/python/scheduled-tasks/README.md
+++ b/samples/durable-task-sdks/python/scheduled-tasks/README.md
@@ -1,0 +1,238 @@
+# Scheduled Tasks
+
+Python | Durable Task SDK
+
+## Description of the Sample
+
+This sample demonstrates the **recurring schedule** feature of the Azure Durable Task Scheduler using the Python SDK. A schedule periodically starts a target orchestration at a fixed interval, and can be paused, resumed, listed, updated, and deleted at runtime.
+
+This is the Python counterpart to the .NET [ScheduleWebApp](../../dotnet/ScheduleWebApp/) sample. It uses the `durabletask.scheduled` package, which builds the schedule feature on top of durable entities and a helper orchestrator.
+
+In this sample:
+1. A schedule is created that runs the `report_orchestrator` every 5 seconds
+2. The schedule fires several times, each run executing the target orchestration
+3. The schedule is paused, then resumed
+4. Schedules are listed by ID prefix
+5. The schedule is deleted
+
+This pattern is useful for:
+- Periodic background jobs (cache clearing, report generation, cleanup)
+- Cron-like recurring workflows without an external scheduler
+- Workflows that must be paused/resumed or reconfigured without redeployment
+
+## Prerequisites
+
+1. [Python 3.10+](https://www.python.org/downloads/)
+2. [Docker](https://www.docker.com/products/docker-desktop/) (for running the emulator)
+3. [Azure CLI](https://docs.microsoft.com/cli/azure/install-azure-cli) (if using a deployed Durable Task Scheduler)
+
+## Configuring Durable Task Scheduler
+
+There are two ways to run this sample locally:
+
+### Using the Emulator (Recommended)
+
+The emulator simulates a scheduler and taskhub in a Docker container, making it ideal for development and learning.
+
+1. Pull the Docker Image for the Emulator:
+   ```bash
+   docker pull mcr.microsoft.com/dts/dts-emulator:latest
+   ```
+
+2. Run the Emulator:
+   ```bash
+   docker run --name dtsemulator -d -p 8080:8080 -p 8082:8082 mcr.microsoft.com/dts/dts-emulator:latest
+   ```
+
+Wait a few seconds for the container to be ready.
+
+Note: The example code automatically uses the default emulator settings (endpoint: `http://localhost:8080`, taskhub: `default`). You don't need to set any environment variables.
+
+### Using a Deployed Scheduler and Taskhub in Azure
+
+Local development with a deployed scheduler:
+
+1. Install the durable task scheduler CLI extension:
+
+    ```bash
+    az upgrade
+    az extension add --name durabletask --allow-preview true
+    ```
+
+2. Create a resource group in a region where the Durable Task Scheduler is available:
+
+    ```bash
+    az provider show --namespace Microsoft.DurableTask --query "resourceTypes[?resourceType=='schedulers'].locations | [0]" --out table
+    ```
+
+    ```bash
+    az group create --name my-resource-group --location <location>
+    ```
+
+3. Create a durable task scheduler resource:
+
+    ```bash
+    az durabletask scheduler create \
+        --resource-group my-resource-group \
+        --name my-scheduler \
+        --ip-allowlist '["0.0.0.0/0"]' \
+        --sku-name "Dedicated" \
+        --sku-capacity 1 \
+        --tags "{'myattribute':'myvalue'}"
+    ```
+
+4. Create a task hub within the scheduler resource:
+
+    ```bash
+    az durabletask taskhub create \
+        --resource-group my-resource-group \
+        --scheduler-name my-scheduler \
+        --name "my-taskhub"
+    ```
+
+5. Grant the current user permission to connect to the `my-taskhub` task hub:
+
+    ```bash
+    subscriptionId=$(az account show --query "id" -o tsv)
+    loggedInUser=$(az account show --query "user.name" -o tsv)
+
+    az role assignment create \
+        --assignee $loggedInUser \
+        --role "Durable Task Data Contributor" \
+        --scope "/subscriptions/$subscriptionId/resourceGroups/my-resource-group/providers/Microsoft.DurableTask/schedulers/my-scheduler/taskHubs/my-taskhub"
+    ```
+
+## How to Run the Sample
+
+Once you have set up either the emulator or deployed scheduler, follow these steps to run the sample:
+
+1. First, activate your Python virtual environment (if you're using one):
+   ```bash
+   python -m venv venv
+   source venv/bin/activate  # On Windows, use: venv\Scripts\activate
+   ```
+
+2. If you're using a deployed scheduler, set environment variables:
+   ```bash
+   export ENDPOINT=$(az durabletask scheduler show \
+       --resource-group my-resource-group \
+       --name my-scheduler \
+       --query "properties.endpoint" \
+       --output tsv)
+
+   export TASKHUB="my-taskhub"
+   ```
+
+3. Install the required packages:
+   ```bash
+   pip install -r requirements.txt
+   ```
+
+4. Start the worker in a terminal:
+   ```bash
+   python worker.py
+   ```
+
+5. In a new terminal (with the virtual environment activated if applicable), run the client:
+   > **Note:** Remember to set the environment variables again if you're using a deployed scheduler.
+
+   ```bash
+   python client.py
+   ```
+
+## Expected Output
+
+### Client Output
+```
+=== Step 1: Create a schedule ===
+  Created schedule 'report-every-5s'
+  Description: ScheduleDescription(schedule_id='report-every-5s', ...)
+
+  Letting the schedule run for ~12 seconds...
+
+=== Step 2: Pause and resume ===
+  Schedule paused
+  Schedule resumed
+
+=== Step 3: List schedules ===
+  Found 1 schedule(s) with prefix 'report-':
+    - report-every-5s: status=ScheduleStatus.ACTIVE, next_run_at=2025-01-01T00:00:10+00:00
+
+=== Step 4: Delete the schedule ===
+  Deleted schedule 'report-every-5s'
+  get_schedule now returns: None
+
+Done!
+```
+
+The worker terminal logs a "Generating report for region 'westus'" line each time the schedule fires.
+
+## Code Walkthrough
+
+### Registering the schedule feature on the worker
+
+Every worker that participates in scheduled tasks must register the schedule
+entity and operation orchestrator via `worker.configure_scheduled_tasks()`:
+
+```python
+worker.add_orchestrator(report_orchestrator)
+worker.configure_scheduled_tasks()
+```
+
+### Creating a schedule
+
+The `ScheduledTaskClient` wraps the base client and exposes schedule management:
+
+```python
+from durabletask.scheduled import ScheduledTaskClient, ScheduleCreationOptions
+
+scheduled_tasks = ScheduledTaskClient(client)
+
+schedule = scheduled_tasks.create_schedule(ScheduleCreationOptions(
+    schedule_id="report-every-5s",
+    orchestration_name="report_orchestrator",
+    interval=timedelta(seconds=5),
+    orchestration_input="westus",
+    start_at=datetime.now(timezone.utc),
+    start_immediately_if_late=True,
+))
+```
+
+### Managing a schedule
+
+`create_schedule` returns a `ScheduleClient` for the lifecycle operations:
+
+```python
+schedule.pause()
+schedule.resume()
+schedule.update(ScheduleUpdateOptions(interval=timedelta(seconds=10)))
+schedule.delete()
+```
+
+### Listing schedules
+
+```python
+from durabletask.scheduled import ScheduleQuery
+
+descriptions = scheduled_tasks.list_schedules(
+    ScheduleQuery(schedule_id_prefix="report-")
+)
+```
+
+## Viewing in the Dashboard
+
+- **Emulator:** Navigate to http://localhost:8082 → select the "default" task hub
+- **Azure:** Navigate to your Scheduler resource in the Azure Portal → Task Hub → Dashboard URL
+
+Each schedule is backed by a durable entity, and each run appears as an
+orchestration instance.
+
+## Related Samples
+
+- [Entities](../entities/) - The durable entity feature that powers schedules
+- [Eternal Orchestrations](../eternal-orchestrations/) - Recurring work via `continue_as_new`
+- [Orchestration Management](../orchestration-management/) - Restart, query, and purge orchestrations
+
+## Learn More
+
+- [Durable Task Scheduler documentation](https://learn.microsoft.com/azure/azure-functions/durable/durable-task-scheduler/develop-with-durable-task-scheduler)

--- a/samples/durable-task-sdks/python/scheduled-tasks/client.py
+++ b/samples/durable-task-sdks/python/scheduled-tasks/client.py
@@ -1,0 +1,101 @@
+import asyncio
+import logging
+import os
+import time
+from datetime import datetime, timedelta, timezone
+from azure.identity import DefaultAzureCredential
+from durabletask.azuremanaged.client import DurableTaskSchedulerClient
+from durabletask.scheduled import (
+    ScheduledTaskClient,
+    ScheduleCreationOptions,
+    ScheduleQuery,
+)
+
+# Configure logging
+logging.basicConfig(level=logging.INFO)
+logger = logging.getLogger(__name__)
+
+SCHEDULE_ID = "report-every-5s"
+# The schedule references the target orchestration by its registered name.
+# The worker (worker.py) registers it as "report_orchestrator".
+ORCHESTRATION_NAME = "report_orchestrator"
+
+
+async def main():
+    """Main entry point demonstrating recurring schedule management."""
+    logger.info("Starting Scheduled Tasks client...")
+
+    # Get environment variables for taskhub and endpoint with defaults
+    taskhub_name = os.getenv("TASKHUB", "default")
+    endpoint = os.getenv("ENDPOINT", "http://localhost:8080")
+
+    print(f"Using taskhub: {taskhub_name}")
+    print(f"Using endpoint: {endpoint}")
+
+    # Set credential to None for emulator, or DefaultAzureCredential for Azure
+    credential = None if endpoint == "http://localhost:8080" else DefaultAzureCredential()
+
+    client = DurableTaskSchedulerClient(
+        host_address=endpoint,
+        secure_channel=endpoint != "http://localhost:8080",
+        taskhub=taskhub_name,
+        token_credential=credential,
+    )
+
+    # The ScheduledTaskClient wraps the base client and exposes schedule
+    # management operations (create, get, list, pause, resume, update, delete).
+    scheduled_tasks = ScheduledTaskClient(client)
+
+    # =========================================================================
+    # 1. Create a recurring schedule
+    # =========================================================================
+    print("\n=== Step 1: Create a schedule ===")
+    schedule = scheduled_tasks.create_schedule(ScheduleCreationOptions(
+        schedule_id=SCHEDULE_ID,
+        orchestration_name=ORCHESTRATION_NAME,
+        interval=timedelta(seconds=5),
+        orchestration_input="westus",
+        start_at=datetime.now(timezone.utc),
+        start_immediately_if_late=True,
+    ))
+    print(f"  Created schedule '{schedule.schedule_id}'")
+    print(f"  Description: {scheduled_tasks.get_schedule(SCHEDULE_ID)}")
+
+    # Let the schedule fire a few times.
+    print("\n  Letting the schedule run for ~12 seconds...")
+    time.sleep(12)
+
+    # =========================================================================
+    # 2. Pause and resume the schedule
+    # =========================================================================
+    print("\n=== Step 2: Pause and resume ===")
+    schedule.pause()
+    print("  Schedule paused")
+    time.sleep(3)
+    schedule.resume()
+    print("  Schedule resumed")
+
+    # =========================================================================
+    # 3. List schedules by prefix
+    # =========================================================================
+    print("\n=== Step 3: List schedules ===")
+    descriptions = scheduled_tasks.list_schedules(
+        ScheduleQuery(schedule_id_prefix="report-")
+    )
+    print(f"  Found {len(descriptions)} schedule(s) with prefix 'report-':")
+    for desc in descriptions:
+        print(f"    - {desc.schedule_id}: status={desc.status}, next_run_at={desc.next_run_at}")
+
+    # =========================================================================
+    # 4. Delete the schedule
+    # =========================================================================
+    print("\n=== Step 4: Delete the schedule ===")
+    schedule.delete()
+    print(f"  Deleted schedule '{SCHEDULE_ID}'")
+    print(f"  get_schedule now returns: {scheduled_tasks.get_schedule(SCHEDULE_ID)}")
+
+    print("\nDone!")
+
+
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/samples/durable-task-sdks/python/scheduled-tasks/requirements.txt
+++ b/samples/durable-task-sdks/python/scheduled-tasks/requirements.txt
@@ -1,0 +1,2 @@
+durabletask-azuremanaged
+azure-identity

--- a/samples/durable-task-sdks/python/scheduled-tasks/worker.py
+++ b/samples/durable-task-sdks/python/scheduled-tasks/worker.py
@@ -1,0 +1,69 @@
+import asyncio
+import logging
+import os
+from azure.identity import DefaultAzureCredential
+from durabletask import task
+from durabletask.azuremanaged.worker import DurableTaskSchedulerWorker
+
+# Configure logging
+logging.basicConfig(level=logging.INFO)
+logger = logging.getLogger(__name__)
+
+
+# Activity function
+def send_report(ctx: task.ActivityContext, region: str) -> str:
+    """Activity that simulates generating and sending a periodic report."""
+    logger.info(f"Generating report for region '{region}'")
+    return f"Report for '{region}' generated"
+
+
+# Target orchestration that the schedule starts on each run
+def report_orchestrator(ctx: task.OrchestrationContext, region: str):
+    """Orchestration started on every schedule tick."""
+    result = yield ctx.call_activity(send_report, input=region)
+    return result
+
+
+async def main():
+    """Main entry point for the worker process."""
+    logger.info("Starting Scheduled Tasks pattern worker...")
+
+    # Get environment variables for taskhub and endpoint with defaults
+    taskhub_name = os.getenv("TASKHUB", "default")
+    endpoint = os.getenv("ENDPOINT", "http://localhost:8080")
+
+    print(f"Using taskhub: {taskhub_name}")
+    print(f"Using endpoint: {endpoint}")
+
+    # Set credential to None for emulator, or DefaultAzureCredential for Azure
+    credential = None if endpoint == "http://localhost:8080" else DefaultAzureCredential()
+
+    with DurableTaskSchedulerWorker(
+        host_address=endpoint,
+        secure_channel=endpoint != "http://localhost:8080",
+        taskhub=taskhub_name,
+        token_credential=credential,
+    ) as worker:
+
+        # Register the target activity and orchestrator
+        worker.add_activity(send_report)
+        worker.add_orchestrator(report_orchestrator)
+
+        # Register the schedule entity and operation orchestrator that power
+        # the recurring schedule feature. This must be called on every worker
+        # that participates in scheduled tasks.
+        worker.configure_scheduled_tasks()
+
+        # Start the worker
+        worker.start()
+
+        try:
+            while True:
+                await asyncio.sleep(1)
+        except KeyboardInterrupt:
+            logger.info("Worker shutdown initiated")
+
+    logger.info("Worker stopped")
+
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/samples/durable-task-sdks/python/sub-orchestrations/worker.py
+++ b/samples/durable-task-sdks/python/sub-orchestrations/worker.py
@@ -1,9 +1,13 @@
 import os
+import logging
 import random
 import time
 from azure.identity import DefaultAzureCredential
 from durabletask import task
 from durabletask.azuremanaged.worker import DurableTaskSchedulerWorker
+
+logging.basicConfig(level=logging.INFO)
+logger = logging.getLogger(__name__)
 
 def get_orders(ctx, _) -> list[str]:
     """Activity function that returns a list of work items"""
@@ -54,7 +58,10 @@ def notify_customer(ctx, order: str) -> bool:
 
 def process_order(ctx, order: str) -> dict:
     """Sub-orchestration function that processes a given order by performing all steps"""
-    print(f'processing order: {order}')
+    # Use a replay-safe logger so this line is not re-emitted on every replay.
+    # (Activities below run once, so their plain print() calls are fine.)
+    olog = ctx.create_replay_safe_logger(logger)
+    olog.info(f'processing order: {order}')
 
      # Check inventory
     inventory_checked = yield ctx.call_activity('check_and_update_inventory', input=order)

--- a/samples/durable-task-sdks/python/versioning/worker.py
+++ b/samples/durable-task-sdks/python/versioning/worker.py
@@ -73,7 +73,9 @@ def versioned_orchestration(ctx: task.OrchestrationContext, name: str):
     results = []
     orch_version = ctx.version
     
-    logger.info(f"Running orchestration with version: {orch_version}")
+    # Use a replay-safe logger so this line is not re-emitted on every replay.
+    olog = ctx.create_replay_safe_logger(logger)
+    olog.info(f"Running orchestration with version: {orch_version}")
     
     # v1.0.0+: Basic hello greeting (all versions)
     hello_result = yield ctx.call_activity(say_hello, input=name)


### PR DESCRIPTION
## Summary

Adds Python Durable Task SDK samples for features that landed in `durabletask-python` after the last batch of Python samples, matching the existing .NET samples as closely as possible. Also weaves a few smaller new features into existing samples and applies a repo-wide replay-safe logging fix.

## New samples (matching .NET)

| Python sample | Feature | .NET counterpart |
|---|---|---|
| `scheduled-tasks` | Recurring schedules via `worker.configure_scheduled_tasks()` + `ScheduledTaskClient` (create/pause/resume/list/delete) | `ScheduleWebApp` |
| `history-export` | Export terminal orchestration history to Azure Blob Storage (`durabletask.extensions.history_export`) | `ExportHistoryWebApp` |
| `bounded-coordinator` | Bounded fan-out batches that reset history with `continue_as_new` | `BoundedCoordinator` |

## Feature integrations into existing samples

- **entities** — delayed (scheduled) entity signals via `signal_time`
- **function-chaining** — type-aware serialization passing a `Greeting` dataclass through the chain with `return_type`
- **fan-out-fan-in** — replay-safe orchestrator logging

## Replay-safe logging sweep

Replaced raw module-logger / `print()` calls made **inside orchestrators** with `ctx.create_replay_safe_logger()` so lines aren't re-emitted on every replay. Affected: `function-chaining`, `human-interaction`, `versioning`, `async-http-api`, `monitoring`, `saga`, and `sub-orchestrations`. Activity-side logging was left as-is (activities run once).

## Docs

- Added **Scheduled Tasks** and **Bounded Coordinator** pattern sections to `docs/patterns.md`
- Filled the `samples/README.md` catalog matrix (Scheduled Tasks, Export History, Bounded Coordinator)

## Verification

All new and modified samples were verified end-to-end against the local **DTS emulator** and **Azurite**:

- `scheduled-tasks` — schedule fired 3× at 5s, pause/resume/list/delete all worked
- `history-export` — exported gzipped JSONL history blobs to Azurite, 0 failures
- `bounded-coordinator` — `{"total_batches": 3, "completed": true}` across batches via `continue_as_new`
- `entities` — delayed reset fired between reads (`before=12, after=0`)
- `function-chaining` — typed `Greeting` round-tripped through all activities
- `fan-out-fan-in` / `monitoring` / `saga` / `sub-orchestrations` — confirmed orchestrator log lines emit exactly once despite replays

> Note: the `scheduled-tasks` and `history-export` samples depend on `durabletask-python` features that may not yet be in a published release. They were validated against an editable install of the current SDK `main`.