### PR TITLE
Align large-payload samples to 256 KiB and fix Durable Functions host.json keys

### DIFF
--- a/.github/skills/migrate-backend-to-dts/SKILL.md
+++ b/.github/skills/migrate-backend-to-dts/SKILL.md
@@ -485,8 +485,8 @@ If your orchestrations pass large inputs/outputs (>10 KB), enable large payload 
       "storageProvider": {
         "type": "azureManaged",
         "connectionStringName": "DURABLE_TASK_SCHEDULER_CONNECTION_STRING",
-        "largePayloadStorageEnabled": true,
-        "largePayloadStorageThresholdBytes": 10240
+        "payloadStorageEnabled": true,
+        "payloadStorageThresholdBytes": 10240
       },
       "hubName": "%TASKHUB_NAME%"
     }
@@ -502,8 +502,8 @@ If your orchestrations pass large inputs/outputs (>10 KB), enable large payload 
       "storageProvider": {
         "type": "azureManaged",
         "connectionStringName": "DURABLE_TASK_SCHEDULER_CONNECTION_STRING",
-        "largePayloadStorageEnabled": true,
-        "largePayloadStorageThresholdBytes": 10240
+        "payloadStorageEnabled": true,
+        "payloadStorageThresholdBytes": 10240
       },
       "hubName": "default"
     }

--- a/.github/skills/migrate-backend-to-dts/references/setup.md
+++ b/.github/skills/migrate-backend-to-dts/references/setup.md
@@ -211,8 +211,8 @@ DTS has a message size limit. For orchestrations that pass large inputs/outputs,
       "storageProvider": {
         "type": "azureManaged",
         "connectionStringName": "DURABLE_TASK_SCHEDULER_CONNECTION_STRING",
-        "largePayloadStorageEnabled": true,
-        "largePayloadStorageThresholdBytes": 10240
+        "payloadStorageEnabled": true,
+        "payloadStorageThresholdBytes": 10240
       },
       "hubName": "%TASKHUB_NAME%"
     }
@@ -220,8 +220,8 @@ DTS has a message size limit. For orchestrations that pass large inputs/outputs,
 }
 ```
 
-- **`largePayloadStorageEnabled`** — set to `true` to enable blob offload
-- **`largePayloadStorageThresholdBytes`** — payloads larger than this (default 10240 = 10 KB) are stored in blob
+- **`payloadStorageEnabled`** — set to `true` to enable blob offload
+- **`payloadStorageThresholdBytes`** — payloads larger than this (default 10240 = 10 KB) are stored in blob
 
 Large payloads are stored in the Azure Storage account referenced by `AzureWebJobsStorage`.
 

--- a/samples/durable-functions/dotnet/LargePayload/README.md
+++ b/samples/durable-functions/dotnet/LargePayload/README.md
@@ -41,7 +41,7 @@ The sample enables these settings in `host.json`:
     "type": "azureManaged",
     "connectionStringName": "DTS_CONNECTION_STRING",
     "payloadStorageEnabled": true,
-    "payloadStorageThresholdBytes": 900000
+    "payloadStorageThresholdBytes": 262144
   },
   "hubName": "%TASKHUB_NAME%"
 }
@@ -54,7 +54,7 @@ When a payload exceeds `payloadStorageThresholdBytes`, the Durable Functions ext
 3. replaces the in-band DTS message with a small blob reference
 4. resolves that blob reference automatically before your function code reads the payload
 
-The sample uses a deterministic, low-compressibility **1.5 MiB** payload by default and a **900,000-byte** threshold so externalization happens before the payload approaches the DTS 1 MiB message boundary.
+The sample uses a deterministic, low-compressibility **1.5 MiB** payload by default and a **262,144-byte (256 KiB)** threshold so externalization happens before the payload approaches the DTS 1 MiB message boundary.
 
 ## Prerequisites
 

--- a/samples/durable-functions/dotnet/LargePayload/host.json
+++ b/samples/durable-functions/dotnet/LargePayload/host.json
@@ -21,7 +21,7 @@
           "type": "azureManaged",
           "connectionStringName": "DTS_CONNECTION_STRING",
           "payloadStorageEnabled": true,
-          "payloadStorageThresholdBytes": 900000
+          "payloadStorageThresholdBytes": 262144
         },
         "hubName": "%TASKHUB_NAME%"
       }

--- a/samples/durable-functions/dotnet/LargePayloadFanOutFanIn/README.md
+++ b/samples/durable-functions/dotnet/LargePayloadFanOutFanIn/README.md
@@ -40,21 +40,21 @@ The sample enables these settings in `host.json`:
   "storageProvider": {
     "type": "azureManaged",
     "connectionStringName": "DTS_CONNECTION_STRING",
-    "largePayloadStorageEnabled": true,
-    "largePayloadStorageThresholdBytes": 900000
+    "payloadStorageEnabled": true,
+    "payloadStorageThresholdBytes": 262144
   },
   "hubName": "%TASKHUB_NAME%"
 }
 ```
 
-When a payload exceeds `largePayloadStorageThresholdBytes`, the Durable Functions extension:
+When a payload exceeds `payloadStorageThresholdBytes`, the Durable Functions extension:
 
 1. compresses the payload with gzip
 2. stores it in blob storage using `AzureWebJobsStorage`
 3. replaces the in-band DTS message with a small blob reference
 4. resolves that blob reference automatically before your function code reads the payload
 
-The sample uses **three deterministic, low-compressibility 1.5 MiB activity payloads** by default and a **900,000-byte** threshold so externalization happens before the payload approaches the DTS 1 MiB message boundary.
+The sample uses **three deterministic, low-compressibility 1.5 MiB activity payloads** by default and a **262,144-byte (256 KiB)** threshold so externalization happens before the payload approaches the DTS 1 MiB message boundary.
 
 ## Prerequisites
 

--- a/samples/durable-functions/dotnet/LargePayloadFanOutFanIn/host.json
+++ b/samples/durable-functions/dotnet/LargePayloadFanOutFanIn/host.json
@@ -20,8 +20,8 @@
         "storageProvider": {
           "type": "azureManaged",
           "connectionStringName": "DTS_CONNECTION_STRING",
-          "largePayloadStorageEnabled": true,
-          "largePayloadStorageThresholdBytes": 900000
+          "payloadStorageEnabled": true,
+          "payloadStorageThresholdBytes": 262144
         },
         "hubName": "%TASKHUB_NAME%"
       }

--- a/samples/durable-task-sdks/dotnet/LargePayload/Program.cs
+++ b/samples/durable-task-sdks/dotnet/LargePayload/Program.cs
@@ -16,7 +16,7 @@ using Microsoft.Extensions.Logging;
 
 const int OneMiB = 1024 * 1024;
 const int DefaultPayloadSizeBytes = 1536 * 1024;
-const int DefaultExternalizeThresholdBytes = 900_000;
+const int DefaultExternalizeThresholdBytes = 262_144;
 const int DefaultWaitTimeoutSeconds = 120;
 const string OrchestrationName = "LargePayloadRoundTrip";
 const string ActivityName = "EchoLargePayload";
@@ -27,11 +27,11 @@ string schedulerConnectionString = builder.Configuration.GetValue<string>("DURAB
     ?? "Endpoint=http://localhost:8080;TaskHub=default;Authentication=None";
 
 int defaultPayloadSizeBytes = GetPositiveInt(builder.Configuration, "PAYLOAD_SIZE_BYTES", DefaultPayloadSizeBytes);
-int externalizeThresholdBytes = GetPositiveInt(builder.Configuration, "EXTERNALIZE_THRESHOLD_BYTES", DefaultExternalizeThresholdBytes);
+int externalizeThresholdBytes = GetPositiveInt(builder.Configuration, "THRESHOLD_BYTES", DefaultExternalizeThresholdBytes);
 
 if (externalizeThresholdBytes > OneMiB)
 {
-    throw new InvalidOperationException($"EXTERNALIZE_THRESHOLD_BYTES must be 1 MiB or smaller. Value: {externalizeThresholdBytes}");
+    throw new InvalidOperationException($"THRESHOLD_BYTES must be 1 MiB or smaller. Value: {externalizeThresholdBytes}");
 }
 
 PayloadStorageSettings payloadStorageSettings = GetPayloadStorageSettings(builder.Configuration);

--- a/samples/durable-task-sdks/dotnet/LargePayload/README.md
+++ b/samples/durable-task-sdks/dotnet/LargePayload/README.md
@@ -20,9 +20,9 @@ Durable Task Scheduler messages have a size limit. The SDK-side blob payload ext
 - replacing the in-band message with a small blob reference
 - resolving that reference automatically before your orchestrator or activity code reads it
 
-The sample uses a deterministic, low-compressibility **1.5 MiB** payload by default and an offload threshold of **900,000 bytes** so payloads are externalized before they approach the 1 MiB scheduler ceiling.
+The sample uses a deterministic, low-compressibility **1.5 MiB** payload by default and an offload threshold of **262,144 bytes (256 KiB)** so payloads are externalized before they approach the 1 MiB scheduler ceiling.
 
-> The SDK extension requires `EXTERNALIZE_THRESHOLD_BYTES` to stay at or below `1,048,576` bytes.
+> `THRESHOLD_BYTES` is a sample-only environment variable. The sample reads it and assigns it to the SDK's `LargePayloadStorageOptions.ThresholdBytes`, which must stay at or below `1,048,576` bytes (1 MiB).
 
 ## Prerequisites
 
@@ -94,7 +94,7 @@ The sample works out of the box locally, but you can override the defaults with 
 | `PAYLOAD_STORAGE_ACCOUNT_URI` | Blob account URI for identity-based storage access | unset |
 | `PAYLOAD_CONTAINER_NAME` | Blob container used for externalized payloads | `durabletask-payloads` |
 | `PAYLOAD_SIZE_BYTES` | Default payload size used by the run endpoint | `1572864` |
-| `EXTERNALIZE_THRESHOLD_BYTES` | Blob offload threshold | `900000` |
+| `THRESHOLD_BYTES` | Blob offload threshold | `262144` |
 | `PAYLOAD_STORAGE_MANAGED_IDENTITY_CLIENT_ID` | Optional user-assigned managed identity client ID for storage | unset |
 | `ASPNETCORE_URLS` | Listen URLs for the web host | framework default |
 


### PR DESCRIPTION
## Summary
Aligns the .NET large-payload samples to the SDK's new default threshold of **262,144 bytes (256 KiB)** and fixes host.json key bugs in the Durable Functions fan-out/fan-in sample and the migrate-backend-to-dts skill.

Related: the .NET SDK default is changing from 900,000 to 262,144 bytes in microsoft/durabletask-dotnet#755.
