### PR TITLE
Set Python large payload sample threshold to 256 KiB

### DIFF
--- a/samples/durable-task-sdks/python/large-payload/README.md
+++ b/samples/durable-task-sdks/python/large-payload/README.md
@@ -168,7 +168,7 @@ Result: "Processed 10000 records (70000 bytes)"
 Done!
 ```
 
-Both orchestrations produce the same type of result. The difference is invisible to the application code — the SDK transparently externalizes the 70 KB payload to blob storage and retrieves it when needed.
+Both orchestrations produce the same type of result. The difference is invisible to the application code — the SDK transparently externalizes the ~342 KB payload to blob storage and retrieves it when needed.
 
 ## Code Walkthrough
 
@@ -179,13 +179,13 @@ The `BlobPayloadStore` is configured with a `BlobPayloadStoreOptions` object:
 ```python
 store = BlobPayloadStore(BlobPayloadStoreOptions(
     connection_string=storage_conn_str,
-    threshold_bytes=1_024,  # Externalize payloads larger than 1 KB
+    threshold_bytes=262_144,  # Externalize payloads larger than 256 KiB
 ))
 ```
 
 Key options:
 - **`connection_string`**: Azure Storage connection string (or `UseDevelopmentStorage=true` for Azurite)
-- **`threshold_bytes`**: Payloads larger than this are externalized (default: 900 KB)
+- **`threshold_bytes`**: Payloads larger than this are externalized (default: 256 KiB)
 - **`max_stored_payload_bytes`**: Maximum payload size that can be stored (default: 10 MB)
 - **`enable_compression`**: Whether to compress payloads with GZip before storing (default: `True`)
 - **`container_name`**: Blob container name (default: `durabletask-payloads`)

--- a/samples/durable-task-sdks/python/large-payload/client.py
+++ b/samples/durable-task-sdks/python/large-payload/client.py
@@ -31,7 +31,7 @@ async def main():
     # Configure the blob payload store — must match the worker configuration
     store = BlobPayloadStore(BlobPayloadStoreOptions(
         connection_string=storage_conn_str,
-        threshold_bytes=1_024,
+        threshold_bytes=262_144,
     ))
 
     # Set credential to None for emulator, or DefaultAzureCredential for Azure
@@ -61,7 +61,7 @@ async def main():
     # --- Large payload (externalized to blob storage) ---
     print("\n--- Large payload (externalized to blob storage) ---")
     instance_id = client.schedule_new_orchestration(
-        "large_payload_orchestrator", input=10_000
+        "large_payload_orchestrator", input=50_000
     )
     logger.info(f"Scheduled orchestration with ID: {instance_id}")
 

--- a/samples/durable-task-sdks/python/large-payload/worker.py
+++ b/samples/durable-task-sdks/python/large-payload/worker.py
@@ -61,11 +61,11 @@ async def main():
     print(f"Using taskhub: {taskhub_name}")
     print(f"Using endpoint: {endpoint}")
 
-    # Configure the blob payload store with a low threshold for demo purposes
+    # Configure the blob payload store (256 KiB threshold, matching the SDK default)
     store = BlobPayloadStore(BlobPayloadStoreOptions(
         connection_string=storage_conn_str,
-        # Use a low threshold so that externalization is visible in the demo
-        threshold_bytes=1_024,
+        # 256 KiB, matching the SDK default; larger payloads are externalized
+        threshold_bytes=262_144,
     ))
 
     # Set credential to None for emulator, or DefaultAzureCredential for Azure


### PR DESCRIPTION
## Summary
Aligns the Durable Task SDK **Python** large-payload sample with the SDK default change (microsoft/durabletask-python#166), which lowers the default externalization threshold to **262,144 bytes (256 KiB)** — matching the .NET SDK (microsoft/durabletask-dotnet#755) and the .NET samples (#343).

## Changes (`samples/durable-task-sdks/python/large-payload/`)
- `worker.py` + `client.py` — `threshold_bytes` `1_024` → `262_144` (256 KiB) in **both** (they must match), with updated comments.
- `client.py` — bumped the "large" demo input `10_000` → `50_000` (~342 KB) so it still exceeds the new threshold and externalizes. The small input (`10`) stays inline.
- `README.md` — updated the payload figure (70 KB → ~342 KB), the code snippet threshold, and the documented default (900 KB → 256 KiB).

## Verification
- `python -m py_compile worker.py client.py` — clean.
- Arithmetic: `"RECORD|" * 50_000` = 350,000 bytes > 262,144, so the large payload externalizes; the small payload stays inline. (The byte-length check is pre-compression.)
