### PR TITLE
Add NodeJs version Information to CustomExceptionProvider Node sampels

### DIFF
--- a/samples/durable-functions/javascript/CustomExceptionPropertyProvider/README.md
+++ b/samples/durable-functions/javascript/CustomExceptionPropertyProvider/README.md
@@ -15,7 +15,7 @@ An activity throws a `BusinessValidationException` carrying structured fields (s
 3. [Docker](https://www.docker.com/products/docker-desktop/) (for the emulator)
 
 > **Note:** The custom exception property provider requires:
-> - The `durable-functions` npm package must include `df.app.setExceptionPropertiesProvider`.
+> - The `durable-functions` npm package >= **3.5.0**, which adds `df.app.setExceptionPropertiesProvider`.
 > - An extension bundle that ships the feature. Use the **main** bundle `Microsoft.Azure.Functions.ExtensionBundle` >= **4.37.1** (configured in `host.json`), or the **preview** bundle `Microsoft.Azure.Functions.ExtensionBundle.Preview` >= **4.44.0**. Older bundles will **not** surface `Properties`.
 > - The Durable Task Scheduler (azure-managed) SDK >= **1.2.0**.
 

--- a/samples/durable-functions/javascript/CustomExceptionPropertyProvider/package.json
+++ b/samples/durable-functions/javascript/CustomExceptionPropertyProvider/package.json
@@ -1,5 +1,6 @@
 {
   "name": "durable-functions-custom-exception-property-provider-js",
+  "version": "1.0.0",
   "description": "Durable Functions JavaScript sample: custom exception property provider for FailureDetails with Durable Task Scheduler",
   "main": "src/functions/*.js",
   "scripts": {

--- a/samples/durable-functions/javascript/CustomExceptionPropertyProvider/package.json
+++ b/samples/durable-functions/javascript/CustomExceptionPropertyProvider/package.json
@@ -1,6 +1,5 @@
 {
   "name": "durable-functions-custom-exception-property-provider-js",
-  "version": "1.0.0",
   "description": "Durable Functions JavaScript sample: custom exception property provider for FailureDetails with Durable Task Scheduler",
   "main": "src/functions/*.js",
   "scripts": {


### PR DESCRIPTION
As titled. Remove the unnecessary version and add durable nodejs version requirement.